### PR TITLE
Add support for more ogn aprs protocols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "flights"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "approx",
  "bytes",
@@ -2910,12 +2910,14 @@ dependencies = [
 
 [[package]]
 name = "ogn_aprs_parser"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "approx",
  "chrono",
  "nom",
  "rstest",
+ "strum",
+ "strum_macros",
  "thiserror 2.0.18",
 ]
 
@@ -4089,6 +4091,24 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/flights/Cargo.toml
+++ b/flights/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "flights"
+version = "0.1.0"
 rust-version = { workspace = true }
 edition = { workspace = true }
 

--- a/ogn_aprs_parser/Cargo.toml
+++ b/ogn_aprs_parser/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "ogn_aprs_parser"
+version = "0.1.0"
 rust-version = { workspace = true }
 edition = { workspace = true }
 
@@ -7,6 +8,8 @@ edition = { workspace = true }
 [dependencies]
 chrono = { workspace = true }
 nom = "8.0.0"
+strum = "0.28.0"
+strum_macros = "0.28.0"
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/ogn_aprs_parser/src/aprs_types.rs
+++ b/ogn_aprs_parser/src/aprs_types.rs
@@ -4,24 +4,21 @@ use crate::errors::{
 };
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, strum_macros::EnumString)]
 pub enum OgnAprsProtocol {
     OGADSB,
+    OGFLR,
+    OGNSKY,
 }
 
-impl std::str::FromStr for OgnAprsProtocol {
-    type Err = APRSMessageParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "OGADSB" => Ok(OgnAprsProtocol::OGADSB),
-            _ => Err(APRSMessageParseError::InvalidOGNAprsProtocol(
-                APRSParseContext {
-                    input: s.to_owned(),
-                    message: "Unsupported OGN APRS Protocol".to_owned(),
-                },
-            )),
-        }
+impl OgnAprsProtocol {
+    pub fn parse_protocol(s: &str) -> Result<Self, APRSMessageParseError> {
+        s.parse::<Self>().map_err(|_| {
+            APRSMessageParseError::InvalidOGNAprsProtocol(APRSParseContext {
+                input: s.to_owned(),
+                message: "Unsupported OGN APRS Protocol".to_owned(),
+            })
+        })
     }
 }
 

--- a/ogn_aprs_parser/src/parse.rs
+++ b/ogn_aprs_parser/src/parse.rs
@@ -182,7 +182,7 @@ fn parse_naive_time(input: &[u8]) -> nom::IResult<&[u8], chrono::NaiveTime, APRS
     };
 
     nom::combinator::map_res(
-        nom::sequence::terminated(take(6usize), tag(b"h".as_slice())),
+        nom::sequence::terminated(take(6usize), take(1usize)),
         parse_to_datetime,
     )
     .parse(input)
@@ -248,9 +248,7 @@ fn parse_aprs_signal_type(
     input: &[u8],
 ) -> nom::IResult<&[u8], OgnAprsProtocol, APRSMessageParseError> {
     let parse_to_aprs_signal_type = |s: &[u8]| -> Result<OgnAprsProtocol, APRSMessageParseError> {
-        std::str::from_utf8(s)
-            .unwrap_or("")
-            .parse::<OgnAprsProtocol>()
+        OgnAprsProtocol::parse_protocol(std::str::from_utf8(s).unwrap_or(""))
     };
     nom::combinator::map_res(
         nom::sequence::terminated(take_until(b",".as_slice()), tag(b",".as_slice())),
@@ -732,5 +730,19 @@ mod tests {
         let result = parse_ogn_aprs_aircraft_beacon(raw_input).unwrap();
 
         assert_eq!(result, expected);
+    }
+
+    mod ogn_aprs_protocol {
+        use super::*;
+
+        #[rstest::rstest]
+        #[case(br"ICA4CA1FF>OGADSB,qAS,LEMDadsb:/140833h4044.38N\00356.29W^024/426/A=040000 id254CA1FF +000fpm  fnRYR6ZM".as_slice())]
+        #[case(br"ICA4CA4EB>OGADSB,qAS,LEMDadsb:/142346h4034.03N\00315.64W^008/370/A=038000 id254CA4EB +000fpm  0.0rot fnRYR4057  regEI-DPG modelB738".as_slice())]
+        #[case(br"ICAA8CBA8>OGFLR,qAS,MontCAIO:/231150z4512.12N\01059.03E^192/106/A=009519 !W20! id21A8CBA8 -039fpm +0.0rot 3.5dB 2e -8.7kHz gps1x2 s6.09 h43 rDF0267".as_slice())]
+        #[case(br"FLR200295>OGFLR,qAS,TT:/071005h4613.92N/01427.53Eg000/000/A=001313 !W00! id1E200295 +000fpm +0.0rot 37.0dB -1.8kHz gps3x5".as_slice())]
+        #[case(br"SKY3E5906>OGNSKY,qAS,SafeSky:/072449h5103.95N/00524.50E'193/034/A=001250 !W65! id1C3E5906 +000fpm gps4x1".as_slice())]
+        fn test_support_for_different_aprs_protocol_types(#[case] input: &[u8]) {
+            parse_ogn_aprs_aircraft_beacon(input).unwrap();
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for the following `dest_call`:
- OGFLR
- OGNSKY

Changes also include use of `strum` crate - which will reduce code additions as more protocols are added.