### PR TITLE
Change `APRSDataSource` trait to better represent operations reading from TCP stream / file IO

### DIFF
--- a/src/core/ingestor/config.rs
+++ b/src/core/ingestor/config.rs
@@ -37,7 +37,7 @@ pub struct AirspaceConfig {
 
 #[derive(serde::Deserialize)]
 pub struct GliderNetConfig {
-    pub host: String,
-    pub port: u64,
+    pub host: std::net::Ipv4Addr,
+    pub port: u16,
     pub filter: String,
 }

--- a/src/core/ingestor/errors.rs
+++ b/src/core/ingestor/errors.rs
@@ -24,12 +24,10 @@ pub enum PacketConversionError {
 pub enum PacketError {
     #[error("Packet Conversion Error: {0}")]
     Conversion(PacketConversionError),
-    #[error("Failed to read line from source: {0}")]
-    StreamReadError(#[from] std::io::Error),
     #[error("Failed to decode protobuf message from file: {0}")]
     DecodeReadError(#[from] prost::DecodeError),
+    #[error("Some IO error: {0}")]
+    IoError(#[from] std::io::Error),
     #[error("Source disconnected or reached end of file")]
     Disconnected,
-    #[error("Connection timed out")]
-    Timeout,
 }

--- a/src/core/ingestor/errors.rs
+++ b/src/core/ingestor/errors.rs
@@ -28,4 +28,8 @@ pub enum PacketError {
     StreamReadError(#[from] std::io::Error),
     #[error("Failed to decode protobuf message from file: {0}")]
     DecodeReadError(#[from] prost::DecodeError),
+    #[error("Source disconnected or reached end of file")]
+    Disconnected,
+    #[error("Connection timed out")]
+    Timeout,
 }

--- a/src/core/ingestor/task.rs
+++ b/src/core/ingestor/task.rs
@@ -6,7 +6,7 @@ use crate::core::ingestor::errors;
 use crate::core::ingestor::protobuf::PbAprsPacket;
 use crate::core::thread_manager::SteppableTask;
 
-pub const DEFAULT_INGESTOR_TIMOUT: std::time::Duration = std::time::Duration::from_secs(5);
+pub const INGESTOR_CONNECTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 pub struct Ingestor {
     source: Box<dyn APRSDataSource>,
@@ -48,7 +48,10 @@ impl Ingestor {
         log::info!("Connecting to TCP stream.");
 
         let address = std::net::SocketAddr::new(config.host.into(), config.port);
-        let mut stream = std::net::TcpStream::connect_timeout(&address, DEFAULT_INGESTOR_TIMOUT)?;
+        let mut stream =
+            std::net::TcpStream::connect_timeout(&address, INGESTOR_CONNECTION_TIMEOUT)?;
+
+        let _ = stream.set_read_timeout(Some(std::time::Duration::from_micros(50)));
 
         authentication_handshake(&mut stream, &config.filter)?;
 
@@ -78,9 +81,14 @@ impl SteppableTask for Ingestor {
 
                 true
             }
+            // This is to handle disconnected channels - only case where we should terminate the task
+            Err(errors::PacketError::Disconnected) => {
+                log::error!("Stream disconnected");
+                false
+            }
             Err(err) => {
                 log::error!("{err}");
-                false
+                true
             }
         }
     }
@@ -124,10 +132,7 @@ impl<R: std::io::Read + Send> APRSDataSource for LiveSource<R> {
                 Ok(packet)
             }
             Err(error) => {
-                if error.kind() == std::io::ErrorKind::TimedOut {
-                    log::error!("TCP stream timed out");
-                }
-                let packet_error = errors::PacketError::StreamReadError(error);
+                let packet_error = errors::PacketError::IoError(error);
                 log::error!("{packet_error}");
                 Err(packet_error)
             }
@@ -264,6 +269,37 @@ mod test {
         }
     }
 
+    struct MockStatefulStream {
+        state: usize,
+    }
+
+    impl std::io::Read for MockStatefulStream {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            match self.state {
+                0 => {
+                    self.state = 1;
+                    let payload = b"PACKET_1\n";
+                    buf[..payload.len()].copy_from_slice(payload);
+                    Ok(payload.len())
+                }
+                1 => {
+                    self.state = 2;
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "simulated network silence",
+                    ))
+                }
+                2 => {
+                    self.state = 3;
+                    let payload = b"PACKET_2\n";
+                    buf[..payload.len()].copy_from_slice(payload);
+                    Ok(payload.len())
+                }
+                _ => Ok(0), // EOF (Disconnected)
+            }
+        }
+    }
+
     #[test]
     fn given_connection_to_stream_when_data_received_then_ingestor_sends_correct_data_and_keeps_running()
      {
@@ -280,6 +316,37 @@ mod test {
         assert_eq!(receiver.recv().unwrap().message, data);
     }
 
+    #[test]
+    fn given_stream_when_idle_timeout_occurs_then_ingestor_keeps_running_and_reads_next_packet() {
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        let mock_stream = MockStatefulStream { state: 0 };
+        let source = LiveSource::new(mock_stream);
+        let mut ingestor = Ingestor::new(source, sender, None);
+
+        let keep_running = ingestor.step();
+        assert!(keep_running, "Expected to keep running after valid packet");
+        assert_eq!(receiver.recv().unwrap().message, "PACKET_1\n");
+
+        let keep_running = ingestor.step();
+        assert!(keep_running, "Expected to keep running after idle timeout");
+        assert!(
+            receiver.try_recv().is_err(),
+            "No data should be sent on timeout"
+        );
+
+        let keep_running = ingestor.step();
+        assert!(
+            keep_running,
+            "Expected to keep running after recovering valid packet"
+        );
+        assert_eq!(receiver.recv().unwrap().message, "PACKET_2\n");
+
+        let keep_running = ingestor.step();
+        assert!(
+            !keep_running,
+            "Expected to stop task when connection drops completely"
+        );
+    }
     #[test]
     fn given_connection_to_stream_when_end_of_stream_then_ingestor_stops_running() {
         let (sender, receiver) = crossbeam_channel::unbounded();

--- a/src/core/ingestor/task.rs
+++ b/src/core/ingestor/task.rs
@@ -6,6 +6,8 @@ use crate::core::ingestor::errors;
 use crate::core::ingestor::protobuf::PbAprsPacket;
 use crate::core::thread_manager::SteppableTask;
 
+pub const DEFAULT_INGESTOR_TIMOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 pub struct Ingestor {
     source: Box<dyn APRSDataSource>,
     sender: crossbeam_channel::Sender<AprsPacket>,
@@ -44,8 +46,9 @@ impl Ingestor {
         write_path: Option<&std::path::Path>,
     ) -> Result<Self, std::io::Error> {
         log::info!("Connecting to TCP stream.");
-        let mut stream =
-            std::net::TcpStream::connect(format!("{0}:{1}", config.host, config.port))?;
+
+        let address = std::net::SocketAddr::new(config.host.into(), config.port);
+        let mut stream = std::net::TcpStream::connect_timeout(&address, DEFAULT_INGESTOR_TIMOUT)?;
 
         authentication_handshake(&mut stream, &config.filter)?;
 
@@ -60,22 +63,20 @@ impl Ingestor {
 impl SteppableTask for Ingestor {
     fn step(&mut self) -> bool {
         match self.source.create_aprs_packet() {
-            Ok(packet_packet_opt) => {
-                if let Some(aprs_packet) = packet_packet_opt {
-                    // write to disk
-                    if let Some(writer) = self.writer.as_mut() {
-                        let pb_aprs_packet = PbAprsPacket::from(aprs_packet.clone());
-                        let _ = write_pb_aprs_packet_to_disk(writer, &pb_aprs_packet)
-                            .map_err(|error| log::error!("Failed to log to disk: {error}"));
-                    }
+            Ok(aprs_packet) => {
+                // write to disk
+                if let Some(writer) = self.writer.as_mut() {
+                    let pb_aprs_packet = PbAprsPacket::from(aprs_packet.clone());
+                    let _ = write_pb_aprs_packet_to_disk(writer, &pb_aprs_packet)
+                        .map_err(|error| log::error!("Failed to log to disk: {error}"));
+                }
 
-                    if let Err(err) = self.sender.send(aprs_packet) {
-                        log::error!("Ingestor: Failed to send to channel: {err}");
-                        return false;
-                    }
+                if let Err(err) = self.sender.send(aprs_packet) {
+                    log::error!("Ingestor: Failed to send to channel: {err}");
                     return true;
                 }
-                false
+
+                true
             }
             Err(err) => {
                 log::error!("{err}");
@@ -91,7 +92,7 @@ pub struct AprsPacket {
 }
 
 pub trait APRSDataSource: Send {
-    fn create_aprs_packet(&mut self) -> Result<Option<AprsPacket>, errors::PacketError>;
+    fn create_aprs_packet(&mut self) -> Result<AprsPacket, errors::PacketError>;
 }
 
 struct LiveSource<R: std::io::Read> {
@@ -105,13 +106,13 @@ impl<R: std::io::Read> LiveSource<R> {
     }
 }
 impl<R: std::io::Read + Send> APRSDataSource for LiveSource<R> {
-    fn create_aprs_packet(&mut self) -> Result<Option<AprsPacket>, errors::PacketError> {
+    fn create_aprs_packet(&mut self) -> Result<AprsPacket, errors::PacketError> {
         let mut buffer = Vec::new();
         match std::io::BufRead::read_until(&mut self.reader, b'\n', &mut buffer) {
             Ok(bytes_read) => {
                 if bytes_read == 0 {
-                    log::error!("End of TCP stream");
-                    return Ok(None);
+                    log::info!("End of TCP stream");
+                    return Err(errors::PacketError::Disconnected);
                 }
 
                 let timestamp = std::time::SystemTime::now();
@@ -120,9 +121,12 @@ impl<R: std::io::Read + Send> APRSDataSource for LiveSource<R> {
                     timestamp,
                     message: buffer.into(),
                 };
-                Ok(Some(packet))
+                Ok(packet)
             }
             Err(error) => {
+                if error.kind() == std::io::ErrorKind::TimedOut {
+                    log::error!("TCP stream timed out");
+                }
                 let packet_error = errors::PacketError::StreamReadError(error);
                 log::error!("{packet_error}");
                 Err(packet_error)
@@ -148,12 +152,12 @@ impl ReplaySource {
     }
 }
 impl APRSDataSource for ReplaySource {
-    fn create_aprs_packet(&mut self) -> Result<Option<AprsPacket>, errors::PacketError> {
+    fn create_aprs_packet(&mut self) -> Result<AprsPacket, errors::PacketError> {
         let position = usize::try_from(self.cursor.position())
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
 
         if position >= self.cursor.get_ref().len() {
-            return Ok(None);
+            return Err(errors::PacketError::Disconnected);
         }
 
         match PbAprsPacket::decode_length_delimited(&mut self.cursor) {
@@ -179,7 +183,9 @@ impl APRSDataSource for ReplaySource {
                         }
                     }
                 }
-                Ok(Some(pb_aprs_packet.try_into().unwrap()))
+                pb_aprs_packet
+                    .try_into()
+                    .map_err(errors::PacketError::Conversion)
             }
             Err(error) => {
                 let decode_error = errors::PacketError::DecodeReadError(error);
@@ -388,24 +394,24 @@ mod test {
 
         let start = std::time::Instant::now();
 
-        let p1 = source.create_aprs_packet().unwrap().unwrap();
+        let p1 = source.create_aprs_packet().unwrap();
         assert_eq!(p1.message, "packet 1\n");
         let elapsed_p1 = start.elapsed().as_millis();
         assert!(elapsed_p1.abs_diff(0) <= 5);
 
-        let p2 = source.create_aprs_packet().unwrap().unwrap();
+        let p2 = source.create_aprs_packet().unwrap();
         assert_eq!(p2.message, "packet 2\n");
         let elapsed_p2 = start.elapsed().as_millis();
         assert!(elapsed_p2 >= 50);
         assert!(elapsed_p2.abs_diff(50) <= 5);
 
-        let p3 = source.create_aprs_packet().unwrap().unwrap();
+        let p3 = source.create_aprs_packet().unwrap();
         assert_eq!(p3.message, "packet 3\n");
         let elapsed_p3 = start.elapsed().as_millis();
         assert!(elapsed_p3 >= 100);
         assert!(elapsed_p3.abs_diff(100) <= 5);
 
-        let p4 = source.create_aprs_packet().unwrap();
-        assert!(p4.is_none());
+        let p4 = source.create_aprs_packet().is_err();
+        assert!(p4);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ mod test {
             read_path: Some(read_path),
             write_path: None,
             glidernet: GliderNetConfig {
-                host: String::new(),
+                host: std::net::Ipv4Addr::LOCALHOST,
                 port: 0,
                 filter: String::new(),
             },


### PR DESCRIPTION
`APRSDataSource` trait used to `create_aprs_packet` method as:
```rust
pub trait APRSDataSource: Send {
    fn create_aprs_packet(&mut self) -> Result<Option<AprsPacket>, errors::PacketError>;
}
```
This presents a challenge when dealing with server-side silence on a TCP stream would result in the ingestor returning `false` on `step()`, which will terminate the program.

This change in the API to 
```rust
pub trait APRSDataSource: Send {
    fn create_aprs_packet(&mut self) -> Result<AprsPacket, errors::PacketError>;
}
```
and extending the `PacketError` enum to include:
```rust
    #[error("Source disconnected or reached end of file")]
    Disconnected,

```
