### PR TITLE
Add specific task state for `SteppableTask` trait instead of simple `bool`

### DIFF
--- a/src/core/airspace/task.rs
+++ b/src/core/airspace/task.rs
@@ -1,6 +1,6 @@
 use crate::core::airspace::detail::Airspace;
 use crate::core::parser::Aircraft;
-use crate::core::thread_manager::SteppableTask;
+use crate::core::thread_manager::{SteppableTask, TaskState};
 
 pub struct AirspaceStore {
     inner: std::sync::Arc<std::sync::RwLock<Airspace>>,
@@ -27,31 +27,26 @@ impl AirspaceStore {
 }
 
 impl SteppableTask for AirspaceStore {
-    fn step(&mut self) -> bool {
+    fn step(&mut self) -> TaskState {
         let mut aircrafts = Vec::new();
-        let mut disconnected_channel = false;
-        loop {
-            match self.aircraft_receiver.try_recv() {
-                Ok(aircraft) => {
-                    aircrafts.push(aircraft);
-                }
-                Err(crossbeam_channel::TryRecvError::Empty) => break,
-                Err(crossbeam_channel::TryRecvError::Disconnected) => {
-                    log::error!("Upstream disconnected");
-                    disconnected_channel = true;
-                    break;
-                }
+
+        match self.aircraft_receiver.try_recv() {
+            Ok(aircraft) => {
+                aircrafts.push(aircraft);
+            }
+            Err(crossbeam_channel::TryRecvError::Empty) => {
+                return TaskState::Running;
+            }
+            Err(crossbeam_channel::TryRecvError::Disconnected) => {
+                log::error!("AirspaceStore upstream disconnected");
+                return TaskState::Errored("AirspaceStore upstream disconnected".to_string());
             }
         }
 
         if let Ok(mut airspace) = self.inner.write() {
             airspace.update(aircrafts);
-            if disconnected_channel {
-                return false;
-            }
-            return true;
         }
-        false
+        TaskState::Running
     }
 }
 #[derive(Clone)]
@@ -79,23 +74,30 @@ mod tests {
     }
 
     #[test]
-    fn test_step_active_channel_returns_true() {
-        let (_sender, mut store) = setup_store();
+    fn when_upstream_channel_is_non_empty_and_connected_then_step_returns_running_state() {
+        let (sender, mut store) = setup_store();
+        let dummy_aircraft =
+            create_dummy_aircraft_at_time(chrono::Utc::now(), ICAOAddress::new(0).unwrap());
+        sender.send(dummy_aircraft).unwrap();
 
-        assert!(store.step());
+        assert_eq!(store.step(), TaskState::Running);
     }
 
     #[test]
-    fn test_step_disconnected_empty_channel_returns_false() {
+    fn when_upstream_channel_is_empty_and_disconnected_then_step_returns_errored_state() {
         let (sender, mut store) = setup_store();
 
         drop(sender);
 
-        assert!(!store.step());
+        assert_eq!(
+            store.step(),
+            TaskState::Errored("AirspaceStore upstream disconnected".to_owned())
+        );
     }
 
     #[test]
-    fn test_when_step_sender_is_dropped_then_store_stops_stepping() {
+    fn when_upstream_channel_is_non_empty_and_disconnected_then_step_returns_running_state_then_errors_on_next()
+     {
         let (sender, mut store) = setup_store();
 
         let dummy_aircraft =
@@ -103,7 +105,13 @@ mod tests {
 
         sender.send(dummy_aircraft).unwrap();
         drop(sender);
+        // we still continue to finish processing the disconnected queue
+        assert_eq!(store.step(), TaskState::Running);
 
-        assert!(!store.step());
+        // when queue is empty, and channel is disconnected, next step() should error
+        assert_eq!(
+            store.step(),
+            TaskState::Errored("AirspaceStore upstream disconnected".to_owned())
+        );
     }
 }

--- a/src/core/airspace/task.rs
+++ b/src/core/airspace/task.rs
@@ -80,7 +80,7 @@ mod tests {
             create_dummy_aircraft_at_time(chrono::Utc::now(), ICAOAddress::new(0).unwrap());
         sender.send(dummy_aircraft).unwrap();
 
-        assert_eq!(store.step(), TaskState::Running);
+        assert!(matches!(store.step(), TaskState::Running));
     }
 
     #[test]
@@ -89,7 +89,7 @@ mod tests {
 
         drop(sender);
 
-        assert_eq!(store.step(), TaskState::Completed);
+        assert!(matches!(store.step(), TaskState::Completed));
     }
 
     #[test]
@@ -103,9 +103,9 @@ mod tests {
         sender.send(dummy_aircraft).unwrap();
         drop(sender);
         // we still continue to finish processing the disconnected queue
-        assert_eq!(store.step(), TaskState::Running);
+        assert!(matches!(store.step(), TaskState::Running));
 
         // when queue is empty, and channel is disconnected, next step() should error
-        assert_eq!(store.step(), TaskState::Completed);
+        assert!(matches!(store.step(), TaskState::Completed));
     }
 }

--- a/src/core/airspace/task.rs
+++ b/src/core/airspace/task.rs
@@ -39,7 +39,7 @@ impl SteppableTask for AirspaceStore {
             }
             Err(crossbeam_channel::TryRecvError::Disconnected) => {
                 log::error!("AirspaceStore upstream disconnected");
-                return TaskState::Errored("AirspaceStore upstream disconnected".to_string());
+                return TaskState::Completed;
             }
         }
 
@@ -89,10 +89,7 @@ mod tests {
 
         drop(sender);
 
-        assert_eq!(
-            store.step(),
-            TaskState::Errored("AirspaceStore upstream disconnected".to_owned())
-        );
+        assert_eq!(store.step(), TaskState::Completed);
     }
 
     #[test]
@@ -109,9 +106,6 @@ mod tests {
         assert_eq!(store.step(), TaskState::Running);
 
         // when queue is empty, and channel is disconnected, next step() should error
-        assert_eq!(
-            store.step(),
-            TaskState::Errored("AirspaceStore upstream disconnected".to_owned())
-        );
+        assert_eq!(store.step(), TaskState::Completed);
     }
 }

--- a/src/core/ingestor/task.rs
+++ b/src/core/ingestor/task.rs
@@ -321,7 +321,7 @@ mod test {
 
         let keep_running = ingestor.step();
 
-        assert_eq!(keep_running, TaskState::Running);
+        assert!(matches!(keep_running, TaskState::Running));
         assert_eq!(receiver.recv().unwrap().message, data);
     }
 
@@ -334,12 +334,12 @@ mod test {
 
         let keep_running = ingestor.step();
         // Expected to keep running after valid packet
-        assert_eq!(keep_running, TaskState::Running);
+        assert!(matches!(keep_running, TaskState::Running));
         assert_eq!(receiver.recv().unwrap().message, "PACKET_1\n");
 
         let keep_running = ingestor.step();
         // Expected to keep running after idle timeout
-        assert_eq!(keep_running, TaskState::Running);
+        assert!(matches!(keep_running, TaskState::Running));
         assert!(
             receiver.try_recv().is_err(),
             "No data should be sent on timeout"
@@ -347,12 +347,12 @@ mod test {
 
         let keep_running = ingestor.step();
         // Expected to keep running after recovering valid packet
-        assert_eq!(keep_running, TaskState::Running);
+        assert!(matches!(keep_running, TaskState::Running));
         assert_eq!(receiver.recv().unwrap().message, "PACKET_2\n");
 
         let keep_running = ingestor.step();
         // Expected to stop task when TCP stream is disconnected.
-        assert_eq!(keep_running, TaskState::Completed);
+        assert!(matches!(keep_running, TaskState::Completed));
     }
     #[test]
     fn given_connection_to_stream_when_end_of_stream_then_ingestor_stops_running() {
@@ -364,7 +364,7 @@ mod test {
 
         let keep_running = ingestor.step();
 
-        assert_eq!(keep_running, TaskState::Completed);
+        assert!(matches!(keep_running, TaskState::Completed));
 
         assert!(receiver.try_recv().is_err(), "Channel should be empty");
     }
@@ -420,7 +420,7 @@ mod test {
         let mut ingestor = Ingestor::new(source, sender, None);
         let mut cont = true;
         while cont {
-            cont = ingestor.step() == TaskState::Running;
+            cont = matches!(ingestor.step(), TaskState::Running);
         }
 
         // drop ingestor to flush writer

--- a/src/core/ingestor/task.rs
+++ b/src/core/ingestor/task.rs
@@ -6,7 +6,7 @@ use crate::core::ingestor::config::GliderNetConfig;
 use crate::core::ingestor::disk::write_pb_aprs_packet_to_disk;
 use crate::core::ingestor::errors;
 use crate::core::ingestor::protobuf::PbAprsPacket;
-use crate::core::thread_manager::SteppableTask;
+use crate::core::thread_manager::{SteppableTask, TaskState};
 
 pub const INGESTOR_CONNECTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
@@ -73,7 +73,7 @@ impl Ingestor {
 }
 
 impl SteppableTask for Ingestor {
-    fn step(&mut self) -> bool {
+    fn step(&mut self) -> TaskState {
         match self.source.create_aprs_packet() {
             Ok(aprs_packet) => {
                 // write to disk
@@ -85,19 +85,19 @@ impl SteppableTask for Ingestor {
 
                 if let Err(err) = self.sender.send(aprs_packet) {
                     log::error!("Ingestor: Failed to send to channel: {err}");
-                    return true;
+                    return TaskState::Running;
                 }
 
-                true
+                TaskState::Running
             }
             // This is to handle disconnected channels - only case where we should terminate the task
             Err(errors::PacketError::Disconnected) => {
                 log::error!("Stream disconnected");
-                false
+                TaskState::Errored("TCP stream disconnected".to_string())
             }
             Err(err) => {
                 log::error!("{err}");
-                true
+                TaskState::Running
             }
         }
     }
@@ -245,7 +245,7 @@ mod test {
         write_pb_aprs_packet_to_disk,
     };
     use crate::core::ingestor::task::{AprsPacket, PbAprsPacket};
-    use crate::core::thread_manager::SteppableTask;
+    use crate::core::thread_manager::{SteppableTask, TaskState};
     use crate::test_utilities::{TestPath, test_path};
 
     struct MockStream {
@@ -321,7 +321,7 @@ mod test {
 
         let keep_running = ingestor.step();
 
-        assert!(keep_running);
+        assert_eq!(keep_running, TaskState::Running);
         assert_eq!(receiver.recv().unwrap().message, data);
     }
 
@@ -333,27 +333,28 @@ mod test {
         let mut ingestor = Ingestor::new(source, sender, None);
 
         let keep_running = ingestor.step();
-        assert!(keep_running, "Expected to keep running after valid packet");
+        // Expected to keep running after valid packet
+        assert_eq!(keep_running, TaskState::Running);
         assert_eq!(receiver.recv().unwrap().message, "PACKET_1\n");
 
         let keep_running = ingestor.step();
-        assert!(keep_running, "Expected to keep running after idle timeout");
+        // Expected to keep running after idle timeout
+        assert_eq!(keep_running, TaskState::Running);
         assert!(
             receiver.try_recv().is_err(),
             "No data should be sent on timeout"
         );
 
         let keep_running = ingestor.step();
-        assert!(
-            keep_running,
-            "Expected to keep running after recovering valid packet"
-        );
+        // Expected to keep running after recovering valid packet
+        assert_eq!(keep_running, TaskState::Running);
         assert_eq!(receiver.recv().unwrap().message, "PACKET_2\n");
 
         let keep_running = ingestor.step();
-        assert!(
-            !keep_running,
-            "Expected to stop task when connection drops completely"
+        // Expected to stop task when connection drops completely
+        assert_eq!(
+            keep_running,
+            TaskState::Errored("TCP stream disconnected".to_string())
         );
     }
     #[test]
@@ -366,7 +367,11 @@ mod test {
 
         let keep_running = ingestor.step();
 
-        assert!(!keep_running);
+        assert_eq!(
+            keep_running,
+            TaskState::Errored("TCP stream disconnected".to_string())
+        );
+
         assert!(receiver.try_recv().is_err(), "Channel should be empty");
     }
 
@@ -421,7 +426,7 @@ mod test {
         let mut ingestor = Ingestor::new(source, sender, None);
         let mut cont = true;
         while cont {
-            cont = ingestor.step();
+            cont = ingestor.step() == TaskState::Running;
         }
 
         // drop ingestor to flush writer

--- a/src/core/ingestor/task.rs
+++ b/src/core/ingestor/task.rs
@@ -93,7 +93,7 @@ impl SteppableTask for Ingestor {
             // This is to handle disconnected channels - only case where we should terminate the task
             Err(errors::PacketError::Disconnected) => {
                 log::error!("Stream disconnected");
-                TaskState::Errored("TCP stream disconnected".to_string())
+                TaskState::Completed
             }
             Err(err) => {
                 log::error!("{err}");
@@ -351,11 +351,8 @@ mod test {
         assert_eq!(receiver.recv().unwrap().message, "PACKET_2\n");
 
         let keep_running = ingestor.step();
-        // Expected to stop task when connection drops completely
-        assert_eq!(
-            keep_running,
-            TaskState::Errored("TCP stream disconnected".to_string())
-        );
+        // Expected to stop task when TCP stream is disconnected.
+        assert_eq!(keep_running, TaskState::Completed);
     }
     #[test]
     fn given_connection_to_stream_when_end_of_stream_then_ingestor_stops_running() {
@@ -367,10 +364,7 @@ mod test {
 
         let keep_running = ingestor.step();
 
-        assert_eq!(
-            keep_running,
-            TaskState::Errored("TCP stream disconnected".to_string())
-        );
+        assert_eq!(keep_running, TaskState::Completed);
 
         assert!(receiver.try_recv().is_err(), "Channel should be empty");
     }

--- a/src/core/parser/task.rs
+++ b/src/core/parser/task.rs
@@ -3,7 +3,7 @@ use ogn_aprs_parser::parse_ogn_aprs_aircraft_beacon;
 use crate::core::ingestor::AprsPacket;
 use crate::core::parser::Aircraft;
 use crate::core::parser::conversion::convert_ogn_aprs_beacon_to_aircraft;
-use crate::core::thread_manager::SteppableTask;
+use crate::core::thread_manager::{SteppableTask, TaskState};
 
 pub struct AircraftParser {
     receiver: crossbeam_channel::Receiver<AprsPacket>,
@@ -23,10 +23,10 @@ impl AircraftParser {
 }
 
 impl SteppableTask for AircraftParser {
-    fn step(&mut self) -> bool {
+    fn step(&mut self) -> TaskState {
         let Ok(aprs_packet) = self.receiver.recv() else {
             log::error!("AircraftParser upstream disconnected");
-            return false;
+            return TaskState::Errored("AircraftParser upstream disconnected".to_string());
         };
 
         match parse_ogn_aprs_aircraft_beacon(&aprs_packet.message) {
@@ -40,6 +40,6 @@ impl SteppableTask for AircraftParser {
             Err(err) => log::debug!("{err:?}"),
         }
 
-        true
+        TaskState::Running
     }
 }

--- a/src/core/parser/task.rs
+++ b/src/core/parser/task.rs
@@ -25,8 +25,8 @@ impl AircraftParser {
 impl SteppableTask for AircraftParser {
     fn step(&mut self) -> TaskState {
         let Ok(aprs_packet) = self.receiver.recv() else {
-            log::error!("AircraftParser upstream disconnected");
-            return TaskState::Errored("AircraftParser upstream disconnected".to_string());
+            log::info!("AircraftParser upstream disconnected. Task complete");
+            return TaskState::Completed;
         };
 
         match parse_ogn_aprs_aircraft_beacon(&aprs_packet.message) {

--- a/src/core/queues.rs
+++ b/src/core/queues.rs
@@ -1,1 +1,0 @@
-struct TaskQueue {}

--- a/src/core/queues.rs
+++ b/src/core/queues.rs
@@ -1,0 +1,1 @@
+struct TaskQueue {}

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -17,13 +17,6 @@ pub trait SteppableTask: Send + 'static {
     fn step(&mut self) -> TaskState;
 }
 
-#[derive(Debug)]
-enum InternalTaskStatus {
-    Pending,     // task created
-    Interrupted, // interrupted by a receiving a stop command
-    Downstream(TaskState),
-}
-
 pub struct ThreadManager {
     current_task_id: ThreadID,
     tasks: std::collections::HashMap<ThreadID, ManagedTask>,
@@ -65,7 +58,7 @@ impl ThreadManager {
     {
         let id = self.current_task_id;
 
-        let task_status = std::sync::Arc::new(std::sync::RwLock::new(InternalTaskStatus::Pending));
+        let task_status = std::sync::Arc::new(std::sync::RwLock::new(ThreadStatus::Active));
         let worker_status = task_status.clone();
         let (stop_sender, stop_receiver) = crossbeam_channel::bounded::<()>(1);
 
@@ -188,16 +181,31 @@ impl Drop for ThreadManager {
     }
 }
 
+#[derive(Debug)]
+enum ThreadStatus {
+    Active,
+    Interrupted, // interrupted by a receiving a stop command
+    Completed,
+    Errored(String),
+}
+
+struct ManagedTask {
+    task_id: TaskID,
+    handle: std::thread::JoinHandle<()>,
+    stop_sender: crossbeam_channel::Sender<()>,
+    status: std::sync::Arc<std::sync::RwLock<ThreadStatus>>,
+}
+
 fn run_task_continuously<T: SteppableTask>(
     mut task: T,
     stop_receiver: &crossbeam_channel::Receiver<()>,
-    task_status: std::sync::Arc<std::sync::RwLock<InternalTaskStatus>>,
+    task_status: std::sync::Arc<std::sync::RwLock<ThreadStatus>>,
 ) {
     loop {
         // Check if we are interrupted
         match stop_receiver.try_recv() {
             Ok(()) | Err(crossbeam_channel::TryRecvError::Disconnected) => {
-                *task_status.write().unwrap() = InternalTaskStatus::Interrupted;
+                *task_status.write().unwrap() = ThreadStatus::Interrupted;
                 break;
             }
             Err(crossbeam_channel::TryRecvError::Empty) => {}
@@ -206,13 +214,11 @@ fn run_task_continuously<T: SteppableTask>(
         match task.step() {
             TaskState::Running => {} // do nothing, task continuing
             TaskState::Completed => {
-                *task_status.write().unwrap() =
-                    InternalTaskStatus::Downstream(TaskState::Completed);
+                *task_status.write().unwrap() = ThreadStatus::Completed;
                 break;
             }
             TaskState::Errored(error) => {
-                *task_status.write().unwrap() =
-                    InternalTaskStatus::Downstream(TaskState::Errored(error));
+                *task_status.write().unwrap() = ThreadStatus::Errored(error);
                 break;
             }
         }
@@ -225,14 +231,14 @@ fn run_task_with_period<T: SteppableTask>(
     mut task: T,
     period: std::time::Duration,
     stop_receiver: &crossbeam_channel::Receiver<()>,
-    task_status: std::sync::Arc<std::sync::RwLock<InternalTaskStatus>>,
+    task_status: std::sync::Arc<std::sync::RwLock<ThreadStatus>>,
 ) {
     let mut next_iteration_time = std::time::Instant::now();
     loop {
         // Check if we are interrupted
         match stop_receiver.try_recv() {
             Ok(()) | Err(crossbeam_channel::TryRecvError::Disconnected) => {
-                *task_status.write().unwrap() = InternalTaskStatus::Interrupted;
+                *task_status.write().unwrap() = ThreadStatus::Interrupted;
                 break;
             }
             Err(crossbeam_channel::TryRecvError::Empty) => {}
@@ -245,13 +251,11 @@ fn run_task_with_period<T: SteppableTask>(
         match task.step() {
             TaskState::Running => {} // do nothing here
             TaskState::Completed => {
-                *task_status.write().unwrap() =
-                    InternalTaskStatus::Downstream(TaskState::Completed);
+                *task_status.write().unwrap() = ThreadStatus::Completed;
                 break;
             }
             TaskState::Errored(error) => {
-                *task_status.write().unwrap() =
-                    InternalTaskStatus::Downstream(TaskState::Errored(error));
+                *task_status.write().unwrap() = ThreadStatus::Errored(error);
                 break;
             }
         }
@@ -279,15 +283,16 @@ fn log_task_finished_status(task: ManagedTask) {
         Ok(_) => {
             let final_status = status.read().unwrap();
             match &*final_status {
-                InternalTaskStatus::Pending => log::error!("{task_id} did not start"),
-                InternalTaskStatus::Interrupted
-                | InternalTaskStatus::Downstream(TaskState::Running) => {
+                ThreadStatus::Active => {
+                    log::warn!("Task {task_id} exited abnormally without updating its status.")
+                }
+                ThreadStatus::Interrupted => {
                     log::info!("Task {task_id}: was interrupted.")
                 }
-                InternalTaskStatus::Downstream(TaskState::Completed) => {
+                ThreadStatus::Completed => {
                     log::info!("Task {task_id} completed successfully")
                 }
-                InternalTaskStatus::Downstream(TaskState::Errored(err)) => {
+                ThreadStatus::Errored(err) => {
                     log::error!("Task was interrupted due to error: {err}")
                 }
             }
@@ -296,13 +301,6 @@ fn log_task_finished_status(task: ManagedTask) {
             log::error!("Task {task_id} panicked: {e:?}");
         }
     }
-}
-
-struct ManagedTask {
-    task_id: TaskID,
-    handle: std::thread::JoinHandle<()>,
-    stop_sender: crossbeam_channel::Sender<()>,
-    status: std::sync::Arc<std::sync::RwLock<InternalTaskStatus>>,
 }
 
 #[cfg(test)]

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -118,11 +118,80 @@ impl ThreadManager {
             let _ = task.handle.join();
         }
     }
+
+    pub fn wait_on_all_tasks(&mut self) {
+        if self.tasks.is_empty() {
+            return;
+        }
+        log::info!("Waiting for all {} tasks to finish", self.tasks.len());
+
+        for (id, task) in self.tasks.drain() {
+            match task.handle.join() {
+                Ok(_) => {
+                    log::debug!("Task {id} terminated gracefully");
+                }
+                Err(e) => {
+                    log::error!("Task {id} panicked: {e:?}");
+                }
+            }
+        }
+    }
 }
 
 impl Default for ThreadManager {
     fn default() -> Self {
         ThreadManager::new()
+    }
+}
+
+impl Drop for ThreadManager {
+    fn drop(&mut self) {
+        // If the developer used your API correctly (wait_on_all_tasks),
+        // this is empty and Drop does absolutely nothing.
+        if self.tasks.is_empty() {
+            return;
+        }
+
+        let remaining = self.tasks.len();
+        log::warn!(
+            "ThreadManager dropping with {remaining} tasks remaining. Enforcing bounded wait..."
+        );
+
+        let timeout_duration = std::time::Duration::from_secs(5);
+        let start_time = std::time::Instant::now();
+
+        let mut remaining_tasks: Vec<_> = self
+            .tasks
+            .drain()
+            .map(|(id, task)| (id, task.handle))
+            .collect();
+
+        // Loop until tasks finish OR we hit the timeout
+        while !remaining_tasks.is_empty() && start_time.elapsed() < timeout_duration {
+            let mut i = 0;
+            while i < remaining_tasks.len() {
+                if remaining_tasks[i].1.is_finished() {
+                    let (id, handle) = remaining_tasks.remove(i);
+                    match handle.join() {
+                        Ok(_) => log::debug!("Task {} completed during drop period.", id),
+                        Err(e) => log::error!("Task {id} panicked during drop: {e:?}"),
+                    }
+                } else {
+                    i += 1;
+                }
+            }
+
+            if !remaining_tasks.is_empty() {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+        }
+
+        if !remaining_tasks.is_empty() {
+            log::error!(
+                "Drop complete: {} tasks did not finish in time and have been detached.",
+                remaining_tasks.len()
+            );
+        }
     }
 }
 

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -115,7 +115,7 @@ impl ThreadManager {
 
     pub fn wait_on_task_finish(&mut self, task_id: TaskID) {
         if let Some(task) = self.tasks.remove(&task_id) {
-            let _ = task.handle.join();
+            log_task_finished_status(task);
         }
     }
 
@@ -125,15 +125,8 @@ impl ThreadManager {
         }
         log::info!("Waiting for all {} tasks to finish", self.tasks.len());
 
-        for (id, task) in self.tasks.drain() {
-            match task.handle.join() {
-                Ok(_) => {
-                    log::debug!("Task {id} terminated gracefully");
-                }
-                Err(e) => {
-                    log::error!("Task {id} panicked: {e:?}");
-                }
-            }
+        for (_id, task) in self.tasks.drain() {
+            log_task_finished_status(task);
         }
     }
 }
@@ -200,8 +193,6 @@ fn run_task_continuously<T: SteppableTask>(
     stop_receiver: &crossbeam_channel::Receiver<()>,
     task_status: std::sync::Arc<std::sync::RwLock<InternalTaskStatus>>,
 ) {
-    *task_status.write().unwrap() = InternalTaskStatus::Downstream(TaskState::Running);
-
     loop {
         // Check if we are interrupted
         match stop_receiver.try_recv() {
@@ -273,6 +264,36 @@ fn run_task_with_period<T: SteppableTask>(
             std::thread::sleep(sleep_duration);
         } else {
             next_iteration_time = now;
+        }
+    }
+}
+
+fn log_task_finished_status(task: ManagedTask) {
+    let ManagedTask {
+        task_id,
+        handle,
+        status,
+        ..
+    } = task;
+    match handle.join() {
+        Ok(_) => {
+            let final_status = status.read().unwrap();
+            match &*final_status {
+                InternalTaskStatus::Pending => log::error!("{task_id} did not start"),
+                InternalTaskStatus::Interrupted
+                | InternalTaskStatus::Downstream(TaskState::Running) => {
+                    log::info!("Task {task_id}: was interrupted.")
+                }
+                InternalTaskStatus::Downstream(TaskState::Completed) => {
+                    log::info!("Task {task_id} completed successfully")
+                }
+                InternalTaskStatus::Downstream(TaskState::Errored(err)) => {
+                    log::error!("Task was interrupted due to error: {err}")
+                }
+            }
+        }
+        Err(e) => {
+            log::error!("Task {task_id} panicked: {e:?}");
         }
     }
 }

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -3,14 +3,14 @@ use log;
 pub type ThreadID = i32;
 pub type TaskID = i32;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum TaskState {
     // Task is still running
     Running,
     // Task defines itself as completed
     Completed,
     // Task encountered an error, and had to terminate
-    Errored(String),
+    Errored(Box<dyn std::error::Error + Send + Sync>),
 }
 
 pub trait SteppableTask: Send + 'static {
@@ -183,10 +183,10 @@ impl Drop for ThreadManager {
 
 #[derive(Debug)]
 enum ThreadStatus {
-    Active,          // Task has been submitted to an active thread
-    Interrupted,     // interrupted by a receiving a stop command
-    Completed,       // Task completed successfully - mapped from `TaskState::Completed`
-    Errored(String), // Task encountered an error - mapped from `TaskState::Errored`
+    Active,      // Task has been submitted to an active thread
+    Interrupted, // interrupted by a receiving a stop command
+    Completed,   // Task completed successfully - mapped from `TaskState::Completed`
+    Errored(Box<dyn std::error::Error + Send + Sync>), // Task encountered an error - mapped from `TaskState::Errored`
 }
 
 struct ManagedTask {

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -3,8 +3,25 @@ use log;
 pub type ThreadID = i32;
 pub type TaskID = i32;
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum TaskState {
+    // Task is still running
+    Running,
+    // Task defines itself as completed
+    Completed,
+    // Task encountered an error, and had to terminate
+    Errored(String),
+}
+
 pub trait SteppableTask: Send + 'static {
-    fn step(&mut self) -> bool;
+    fn step(&mut self) -> TaskState;
+}
+
+#[derive(Debug)]
+enum InternalTaskStatus {
+    Pending,     // task created
+    Interrupted, // interrupted by a receiving a stop command
+    Downstream(TaskState),
 }
 
 pub struct ThreadManager {
@@ -48,15 +65,17 @@ impl ThreadManager {
     {
         let id = self.current_task_id;
 
+        let task_status = std::sync::Arc::new(std::sync::RwLock::new(InternalTaskStatus::Pending));
+        let worker_status = task_status.clone();
         let (stop_sender, stop_receiver) = crossbeam_channel::bounded::<()>(1);
 
         let thread_task: Box<dyn FnOnce() + Send> = if period.is_zero() {
             Box::new(move || {
-                run_task_continuously(task, &stop_receiver);
+                run_task_continuously(task, &stop_receiver, worker_status);
             })
         } else {
             Box::new(move || {
-                run_task_with_period(task, period, &stop_receiver);
+                run_task_with_period(task, period, &stop_receiver, worker_status);
             })
         };
 
@@ -69,8 +88,10 @@ impl ThreadManager {
         self.tasks.insert(
             id,
             ManagedTask {
+                task_id: id,
                 handle,
                 stop_sender,
+                status: task_status,
             },
         );
         self.current_task_id += 1;
@@ -108,15 +129,32 @@ impl Default for ThreadManager {
 fn run_task_continuously<T: SteppableTask>(
     mut task: T,
     stop_receiver: &crossbeam_channel::Receiver<()>,
+    task_status: std::sync::Arc<std::sync::RwLock<InternalTaskStatus>>,
 ) {
+    *task_status.write().unwrap() = InternalTaskStatus::Downstream(TaskState::Running);
+
     loop {
+        // Check if we are interrupted
         match stop_receiver.try_recv() {
-            Ok(()) | Err(crossbeam_channel::TryRecvError::Disconnected) => break,
+            Ok(()) | Err(crossbeam_channel::TryRecvError::Disconnected) => {
+                *task_status.write().unwrap() = InternalTaskStatus::Interrupted;
+                break;
+            }
             Err(crossbeam_channel::TryRecvError::Empty) => {}
         }
-
-        if !task.step() {
-            break;
+        // Check if we should still loop on the task
+        match task.step() {
+            TaskState::Running => {} // do nothing, task continuing
+            TaskState::Completed => {
+                *task_status.write().unwrap() =
+                    InternalTaskStatus::Downstream(TaskState::Completed);
+                break;
+            }
+            TaskState::Errored(error) => {
+                *task_status.write().unwrap() =
+                    InternalTaskStatus::Downstream(TaskState::Errored(error));
+                break;
+            }
         }
 
         std::thread::yield_now();
@@ -127,37 +165,60 @@ fn run_task_with_period<T: SteppableTask>(
     mut task: T,
     period: std::time::Duration,
     stop_receiver: &crossbeam_channel::Receiver<()>,
+    task_status: std::sync::Arc<std::sync::RwLock<InternalTaskStatus>>,
 ) {
-    let mut next_run = std::time::Instant::now();
+    let mut next_iteration_time = std::time::Instant::now();
     loop {
-        if !task.step() {
-            break;
-        }
-        next_run += period;
-        let now = std::time::Instant::now();
-
-        if next_run > now {
-            let sleep_dur = next_run - now;
-            match stop_receiver.recv_timeout(sleep_dur) {
-                Ok(()) | Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
-                Err(crossbeam_channel::RecvTimeoutError::Timeout) => {}
+        // Check if we are interrupted
+        match stop_receiver.try_recv() {
+            Ok(()) | Err(crossbeam_channel::TryRecvError::Disconnected) => {
+                *task_status.write().unwrap() = InternalTaskStatus::Interrupted;
+                break;
             }
-        } else {
-            // Reset drift base if we are lagging badly
-            next_run = now;
+            Err(crossbeam_channel::TryRecvError::Empty) => {}
+        }
 
-            if let Ok(()) = stop_receiver.try_recv() {
+        // Find what is the time for next iteration
+        next_iteration_time += period;
+
+        // Run task & update the task status
+        match task.step() {
+            TaskState::Running => {} // do nothing here
+            TaskState::Completed => {
+                *task_status.write().unwrap() =
+                    InternalTaskStatus::Downstream(TaskState::Completed);
+                break;
+            }
+            TaskState::Errored(error) => {
+                *task_status.write().unwrap() =
+                    InternalTaskStatus::Downstream(TaskState::Errored(error));
                 break;
             }
         }
+
+        // Check if sleep is needed if task completed within the window
+        let now = std::time::Instant::now();
+
+        if next_iteration_time < now {
+            let sleep_duration = next_iteration_time - now;
+            std::thread::sleep(sleep_duration);
+        } else {
+            next_iteration_time = now;
+        }
     }
 }
+
 struct ManagedTask {
+    task_id: TaskID,
     handle: std::thread::JoinHandle<()>,
     stop_sender: crossbeam_channel::Sender<()>,
+    status: std::sync::Arc<std::sync::RwLock<InternalTaskStatus>>,
 }
+
 #[cfg(test)]
 mod tests {
+    use crate::core::thread_manager::TaskState;
+
     use super::{SteppableTask, ThreadManager};
 
     // A simple runnable task for counting and self-stopping
@@ -179,11 +240,15 @@ mod tests {
     }
 
     impl SteppableTask for CountingTask {
-        fn step(&mut self) -> bool {
+        fn step(&mut self) -> TaskState {
             let mut count = self.count.lock().unwrap();
             *count += 1;
             self.sender.send(*count).unwrap();
-            *count < self.limit
+            if *count < self.limit {
+                TaskState::Running
+            } else {
+                TaskState::Completed
+            }
         }
     }
 
@@ -204,11 +269,11 @@ mod tests {
     }
 
     impl SteppableTask for LoopingTask {
-        fn step(&mut self) -> bool {
+        fn step(&mut self) -> TaskState {
             let mut executions = self.executions.lock().unwrap();
             *executions += 1;
             self.sender.send(*executions).unwrap();
-            true // Always return true, so it must be stopped externally
+            TaskState::Running
         }
     }
 

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -183,10 +183,10 @@ impl Drop for ThreadManager {
 
 #[derive(Debug)]
 enum ThreadStatus {
-    Active,
-    Interrupted, // interrupted by a receiving a stop command
-    Completed,
-    Errored(String),
+    Active,          // Task has been submitted to an active thread
+    Interrupted,     // interrupted by a receiving a stop command
+    Completed,       // Task completed successfully - mapped from `TaskState::Completed`
+    Errored(String), // Task encountered an error - mapped from `TaskState::Errored`
 }
 
 struct ManagedTask {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ fn main() {
     } else if let Some(duration) = run_duration {
         std::thread::sleep(duration);
     } else {
+        // run indefinitely until something breaks the chain
         pipeline.wait_on_all_tasks_finish();
     }
     log::info!("Shutting down application.");


### PR DESCRIPTION
This PR changes the signature of a `SteppableTask` trait. Each task now returns a `TaskState` enum, which reflects the state of the task to be more easily represented within the `ThreadManager` struct.

This allows better traceability of errors relating to task failures.