### PR TITLE
Fix IP address resolution

### DIFF
--- a/src/core/ingestor/config.rs
+++ b/src/core/ingestor/config.rs
@@ -37,7 +37,7 @@ pub struct AirspaceConfig {
 
 #[derive(serde::Deserialize)]
 pub struct GliderNetConfig {
-    pub host: std::net::Ipv4Addr,
+    pub host: String,
     pub port: u16,
     pub filter: String,
 }

--- a/src/core/ingestor/task.rs
+++ b/src/core/ingestor/task.rs
@@ -1,3 +1,5 @@
+use std::net::ToSocketAddrs;
+
 use prost::Message;
 
 use crate::core::ingestor::config::GliderNetConfig;
@@ -47,11 +49,18 @@ impl Ingestor {
     ) -> Result<Self, std::io::Error> {
         log::info!("Connecting to TCP stream.");
 
-        let address = std::net::SocketAddr::new(config.host.into(), config.port);
+        let address_str = format!("{}:{}", config.host, config.port);
+
+        let mut resolved_address = address_str.to_socket_addrs()?;
+
+        let address = resolved_address.next().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "Could not resolve host")
+        })?;
+
         let mut stream =
             std::net::TcpStream::connect_timeout(&address, INGESTOR_CONNECTION_TIMEOUT)?;
 
-        let _ = stream.set_read_timeout(Some(std::time::Duration::from_micros(50)));
+        let _ = stream.set_read_timeout(Some(std::time::Duration::from_millis(500)));
 
         authentication_handshake(&mut stream, &config.filter)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ mod test {
             read_path: Some(read_path),
             write_path: None,
             glidernet: GliderNetConfig {
-                host: std::net::Ipv4Addr::LOCALHOST,
+                host: "host".to_string(),
                 port: 0,
                 filter: String::new(),
             },


### PR DESCRIPTION
This PR fixes broken config options by mistakenly changing `host` type in `GliderNetConfig` to `Ipv4Addr`. Reverts it back to String