### PR TITLE
Add conversion to serializable data for Json handler for CentralDiskLogger

### DIFF
--- a/src/core/central_disk_logger/errors.rs
+++ b/src/core/central_disk_logger/errors.rs
@@ -9,6 +9,8 @@ pub enum LoggingError<T> {
     Conversion(T),
     #[error("Failed to send: {0}")]
     SendError(#[from] crossbeam_channel::SendError<DiskLoggerMessage>),
+    #[error("Failed to send: {0}")]
+    Serialization(#[from] serde_json::Error),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/core/central_disk_logger/interface.rs
+++ b/src/core/central_disk_logger/interface.rs
@@ -68,14 +68,20 @@ where
     }
 }
 
-impl<'a, M> LogSender<&'a M> for LoggerHandle<JsonlFormat, M>
+impl<M, T, E> LogSender<T> for LoggerHandle<JsonlFormat, M>
 where
-    M: serde::Serialize + ?Sized,
+    T: TryInto<M, Error = E>,
+    M: serde::Serialize,
 {
-    type Error = errors::LoggingError<serde_json::Error>;
+    type Error = errors::LoggingError<E>;
 
-    fn send(&self, message: &'a M) -> Result<(), Self::Error> {
-        let mut payload = serde_json::to_vec(message).map_err(errors::LoggingError::Conversion)?;
+    fn send(&self, message: T) -> Result<(), Self::Error> {
+        let json_message: M = message
+            .try_into()
+            .map_err(errors::LoggingError::Conversion)?;
+
+        let mut payload =
+            serde_json::to_vec(&json_message).map_err(errors::LoggingError::Serialization)?;
 
         payload.push(b'\n');
 

--- a/src/core/central_disk_logger/testing/integration_tests.rs
+++ b/src/core/central_disk_logger/testing/integration_tests.rs
@@ -106,7 +106,7 @@ fn given_jsonl_logger_when_message_sent_and_stepped_then_correct_json_lines_on_d
     let domain_message = vec!["app_started".to_string(), "disk_ok".to_string()];
 
     handle
-        .send(&domain_message)
+        .send(domain_message)
         .expect("Failed to send json message");
 
     let state = central_logger.step();
@@ -145,7 +145,7 @@ fn given_mixed_loggers_when_messages_sent_then_system_routes_both_formats_correc
         .unwrap();
 
     let json_msg = vec!["concurrent_test".to_string()];
-    jsonl_handle.send(&json_msg).unwrap();
+    jsonl_handle.send(json_msg).unwrap();
 
     central_logger.step();
     central_logger.step();


### PR DESCRIPTION
This PR makes send interface identical to the protobuff equivalent. This allows for the same method signature as `ProtoLogger` - where the `send` message can send a type `T` that implements `TryInto` a `serde::Serializable` trait