### PR TITLE
Standardize Timestamp Across all Modules

### DIFF
--- a/proto/ingestor/ingestor.proto
+++ b/proto/ingestor/ingestor.proto
@@ -5,6 +5,5 @@ import "google/protobuf/timestamp.proto";
 
 message PbAprsPacket{
   google.protobuf.Timestamp timestamp = 1;
-  reserved 2;
-  bytes message = 3;
+  bytes message = 2;
 }

--- a/proto/parser/aircraft.proto
+++ b/proto/parser/aircraft.proto
@@ -4,12 +4,12 @@ package parser;
 import "google/protobuf/timestamp.proto";
 
 message PbAircraft {
-  string                    callsign     = 1;
-  uint32                    icao_address = 2;
-  google.protobuf.Timestamp datetime     = 3;
-  double                    latitude     = 4;
-  double                    longitude    = 5;
-  double                    ground_track = 6;
-  double                    ground_speed = 7;
-  double                    gps_altitude = 8;
+  string                    callsign              = 1;
+  uint32                    icao_address          = 2;
+  google.protobuf.Timestamp broadcasted_timestamp = 3;
+  double                    latitude              = 4;
+  double                    longitude             = 5;
+  double                    ground_track          = 6;
+  double                    ground_speed          = 7;
+  double                    gps_altitude          = 8;
 }

--- a/src/airspace/conversion.rs
+++ b/src/airspace/conversion.rs
@@ -44,8 +44,8 @@ impl TryFrom<PbAirspace> for Airspace {
 
 impl From<Airspace> for PbAirspace {
     fn from(airspace: Airspace) -> Self {
-        let (datetime, icao_to_aircraft_mapping) = airspace.into_inner();
-        let sys_time: SystemTime = datetime.into();
+        let (timestamp, icao_to_aircraft_mapping) = airspace.into_inner();
+        let sys_time: SystemTime = timestamp.into();
         let timestamp = Some(sys_time.into());
 
         let pb_mapping = icao_to_aircraft_mapping

--- a/src/airspace/conversion.rs
+++ b/src/airspace/conversion.rs
@@ -11,15 +11,15 @@ use crate::pb::airspace::{PbAircraftHistory, PbAirspace};
 
 impl TryFrom<PbAirspace> for Airspace {
     type Error = PacketConversionError;
-    fn try_from(packet: PbAirspace) -> Result<Self, Self::Error> {
-        let pb_timestamp = packet
+    fn try_from(pb_airspace: PbAirspace) -> Result<Self, Self::Error> {
+        let pb_timestamp = pb_airspace
             .timestamp
             .ok_or(PacketConversionError::MissingTimestamp)?;
         let sys_timestamp = SystemTime::try_from(pb_timestamp)?;
 
         let timestamp: DateTime<Utc> = sys_timestamp.into();
 
-        let mapping = packet
+        let mapping = pb_airspace
             .icao_to_aircraft_map
             .into_iter()
             .map(|(icao_address_u32, aircraft_history)| {

--- a/src/airspace/detail.rs
+++ b/src/airspace/detail.rs
@@ -7,7 +7,7 @@ use crate::parser::Aircraft;
 
 #[derive(Debug, Clone)]
 pub struct Airspace {
-    datetime: chrono::DateTime<chrono::Utc>,
+    timestamp: chrono::DateTime<chrono::Utc>,
     icao_to_aircraft_map:
         std::collections::HashMap<ICAOAddress, std::collections::VecDeque<Aircraft>>,
 }
@@ -15,16 +15,16 @@ impl Airspace {
     #[must_use]
     pub fn new() -> Self {
         Airspace {
-            datetime: chrono::DateTime::<chrono::Utc>::MIN_UTC,
+            timestamp: chrono::DateTime::<chrono::Utc>::MIN_UTC,
             icao_to_aircraft_map: std::collections::HashMap::new(),
         }
     }
     pub fn from_state(
-        datetime: DateTime<Utc>,
+        timestamp: DateTime<Utc>,
         icao_to_aircraft_map: HashMap<ICAOAddress, VecDeque<Aircraft>>,
     ) -> Self {
         Airspace {
-            datetime,
+            timestamp,
             icao_to_aircraft_map,
         }
     }
@@ -34,13 +34,13 @@ impl Airspace {
 
         while let Some(aircraft) = aircrafts.pop() {
             // find latest aircraft datetime and set as current datetime.
-            if aircraft.datetime > self.datetime {
-                self.datetime = aircraft.datetime;
+            if aircraft.broadcasted_timestamp > self.timestamp {
+                self.timestamp = aircraft.broadcasted_timestamp;
             }
 
             // check that aircraft is within buffer window
-            let cutoff_time = self.datetime - buffer_duration;
-            if aircraft.datetime < cutoff_time {
+            let cutoff_time = self.timestamp - buffer_duration;
+            if aircraft.broadcasted_timestamp < cutoff_time {
                 continue;
             }
 
@@ -49,7 +49,7 @@ impl Airspace {
             // We expect that the new data is normally most recent data, so we check that we can push
             // back into the end of the VecDeque
             if let Some(last) = history.back()
-                && aircraft.datetime >= last.datetime
+                && aircraft.broadcasted_timestamp >= last.broadcasted_timestamp
             {
                 history.push_back(aircraft);
                 continue;
@@ -57,14 +57,15 @@ impl Airspace {
 
             // If it is not new data, try to see the data is old enough to be front of VecDeque
             if let Some(first) = history.front()
-                && aircraft.datetime <= first.datetime
+                && aircraft.broadcasted_timestamp <= first.broadcasted_timestamp
             {
                 history.push_front(aircraft);
                 continue;
             }
 
             // It is somewhere in between
-            let idx = history.partition_point(|x| x.datetime < aircraft.datetime);
+            let idx = history
+                .partition_point(|x| x.broadcasted_timestamp < aircraft.broadcasted_timestamp);
             history.insert(idx, aircraft);
         }
         self.prune(buffer_duration);
@@ -79,8 +80,8 @@ impl Airspace {
     }
 
     #[must_use]
-    pub fn get_datetime(&self) -> chrono::DateTime<chrono::Utc> {
-        self.datetime
+    pub fn get_timestamp(&self) -> chrono::DateTime<chrono::Utc> {
+        self.timestamp
     }
 
     #[must_use]
@@ -97,18 +98,18 @@ impl Airspace {
         chrono::DateTime<chrono::Utc>,
         std::collections::HashMap<ICAOAddress, std::collections::VecDeque<Aircraft>>,
     ) {
-        (self.datetime, self.icao_to_aircraft_map)
+        (self.timestamp, self.icao_to_aircraft_map)
     }
 
     fn prune(&mut self, buffer_duration: chrono::Duration) {
         let cutoff_time = self
-            .datetime
+            .timestamp
             .checked_sub_signed(buffer_duration)
             .unwrap_or(chrono::DateTime::<chrono::Utc>::MIN_UTC);
 
         for aircraft_history in self.icao_to_aircraft_map.values_mut() {
             while let Some(aircraft) = aircraft_history.front() {
-                if aircraft.datetime < cutoff_time {
+                if aircraft.broadcasted_timestamp < cutoff_time {
                     aircraft_history.pop_front();
                 } else {
                     break;
@@ -152,7 +153,7 @@ mod tests {
         let now_datetime = chrono::Utc::now();
         let buffer_duration = chrono::TimeDelta::seconds(5);
         let mut airspace = Airspace {
-            datetime: now_datetime,
+            timestamp: now_datetime,
             icao_to_aircraft_map: std::collections::HashMap::new(),
         };
 
@@ -178,7 +179,10 @@ mod tests {
             .get(&expected_aircraft_1_icao_address)
             .expect("expected a VecDeque for aircraft 1");
         assert_eq!(aircraft_1_history.len(), 1);
-        assert_eq!(aircraft_1_history[0].datetime, expected_aircraft_1_datetime);
+        assert_eq!(
+            aircraft_1_history[0].broadcasted_timestamp,
+            expected_aircraft_1_datetime
+        );
 
         // check aircraft 2 inserted
         let aircraft_2_history = airspace
@@ -186,7 +190,10 @@ mod tests {
             .get(&expected_aircraft_2_icao_address)
             .expect("expected a VecDeque for aircraft 1");
         assert_eq!(aircraft_2_history.len(), 1);
-        assert_eq!(aircraft_2_history[0].datetime, expected_aircraft_2_datetime);
+        assert_eq!(
+            aircraft_2_history[0].broadcasted_timestamp,
+            expected_aircraft_2_datetime
+        );
     }
     #[test]
     fn when_adding_aircrafts_to_empty_entries_then_airspace_datetime_is_correctly_updated() {
@@ -207,7 +214,7 @@ mod tests {
         ];
 
         airspace.update(aircrafts, buffer_duration);
-        assert_eq!(airspace.datetime, now_datetime);
+        assert_eq!(airspace.timestamp, now_datetime);
     }
 
     #[cfg(test)]
@@ -234,7 +241,7 @@ mod tests {
             )];
             let buffer_duration = chrono::TimeDelta::seconds(5);
             let mut airspace = Airspace {
-                datetime: to_datetime("00:01:00"),
+                timestamp: to_datetime("00:01:00"),
                 icao_to_aircraft_map: existing_order_mapping.into_iter().collect(),
             };
 
@@ -247,7 +254,7 @@ mod tests {
                 .expect("expected to have history");
 
             assert_eq!(history.len(), 3);
-            assert_eq!(history[2].datetime, time_c);
+            assert_eq!(history[2].broadcasted_timestamp, time_c);
         }
         #[test]
         fn and_aircraft_timestamp_is_oldest_then_correct_order_is_added() {
@@ -270,7 +277,7 @@ mod tests {
             )];
             let buffer_duration = chrono::TimeDelta::seconds(5);
             let mut airspace = Airspace {
-                datetime: to_datetime("00:01:00"),
+                timestamp: to_datetime("00:01:00"),
                 icao_to_aircraft_map: existing_order_mapping.into_iter().collect(),
             };
             let new_data = vec![create_dummy_aircraft_at_time(time_a, aircraft_icao_address)];
@@ -282,7 +289,7 @@ mod tests {
                 .expect("expected to have history");
 
             assert_eq!(history.len(), 3);
-            assert_eq!(history[2].datetime, time_c);
+            assert_eq!(history[2].broadcasted_timestamp, time_c);
         }
         #[test]
         fn and_aircraft_timestamp_is_somewhere_in_between_then_correct_order_is_added() {
@@ -309,7 +316,7 @@ mod tests {
 
             let buffer_duration = chrono::TimeDelta::seconds(5);
             let mut airspace = Airspace {
-                datetime: to_datetime("00:01:00"),
+                timestamp: to_datetime("00:01:00"),
                 icao_to_aircraft_map: existing_order_mapping.into_iter().collect(),
             };
             let new_data = vec![create_dummy_aircraft_at_time(time_c, aircraft_icao_address)];
@@ -321,7 +328,7 @@ mod tests {
                 .expect("expected to have history");
 
             assert_eq!(history.len(), 4);
-            assert_eq!(history[2].datetime, time_c);
+            assert_eq!(history[2].broadcasted_timestamp, time_c);
         }
     }
 }

--- a/src/ingestor/conversion.rs
+++ b/src/ingestor/conversion.rs
@@ -1,28 +1,32 @@
+use std::time::SystemTime;
+
 use crate::ingestor::errors::APRSPacketConversionError;
 use crate::ingestor::task::AprsPacket;
 use crate::pb::ingestor::PbAprsPacket;
 
 impl TryFrom<PbAprsPacket> for AprsPacket {
     type Error = APRSPacketConversionError;
-    fn try_from(packet: PbAprsPacket) -> Result<Self, Self::Error> {
-        let timestamp = packet
+    fn try_from(pb_packet: PbAprsPacket) -> Result<Self, Self::Error> {
+        let pb_timestamp = pb_packet
             .timestamp
-            .ok_or(APRSPacketConversionError::MissingTimestamp)?
-            .try_into()?;
+            .ok_or(APRSPacketConversionError::MissingTimestamp)?;
+
+        let sys_time: SystemTime = pb_timestamp.try_into()?;
+        let timestamp = sys_time.into();
 
         Ok(Self {
             timestamp,
-            message: packet.message,
+            message: pb_packet.message,
         })
     }
 }
 
 impl From<AprsPacket> for PbAprsPacket {
     fn from(packet: AprsPacket) -> Self {
-        let pb_timestamp = packet.timestamp.into();
+        let sys_time: SystemTime = packet.timestamp.into();
 
         Self {
-            timestamp: Some(pb_timestamp),
+            timestamp: Some(sys_time.into()),
             message: packet.message,
         }
     }

--- a/src/ingestor/task.rs
+++ b/src/ingestor/task.rs
@@ -1,5 +1,6 @@
 use std::net::ToSocketAddrs;
 
+use chrono::{DateTime, Utc};
 use prost::Message;
 
 use crate::core::central_disk_logger::{LogSender, ProtoLoggerHandle};
@@ -97,7 +98,7 @@ impl SteppableTask for Ingestor {
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AprsPacket {
-    pub timestamp: std::time::SystemTime,
+    pub timestamp: DateTime<Utc>,
     pub message: bytes::Bytes,
 }
 
@@ -125,7 +126,7 @@ impl<R: std::io::Read + Send> APRSDataSource for LiveSource<R> {
                     return Err(errors::PacketError::Disconnected);
                 }
 
-                let timestamp = std::time::SystemTime::now();
+                let timestamp = Utc::now();
 
                 let packet = AprsPacket {
                     timestamp,

--- a/src/parser/conversion.rs
+++ b/src/parser/conversion.rs
@@ -12,7 +12,7 @@ pub struct Aircraft {
     pub callsign: String,
     #[serde(with = "icao_serde")]
     pub icao_address: ICAOAddress,
-    pub datetime: chrono::DateTime<chrono::Utc>,
+    pub broadcasted_timestamp: chrono::DateTime<chrono::Utc>,
     pub latitude: f64,
     pub longitude: f64,
     pub ground_track: f64,
@@ -34,7 +34,7 @@ pub fn convert_ogn_aprs_beacon_to_aircraft(
     Aircraft {
         callsign: aircraft_beacon.callsign,
         icao_address: aircraft_beacon.ogn_beacon_id.icao_address,
-        datetime,
+        broadcasted_timestamp: datetime,
         latitude: aircraft_beacon.latitude,
         longitude: aircraft_beacon.longitude,
         ground_track: aircraft_beacon.ground_track,
@@ -72,15 +72,15 @@ impl TryFrom<PbAircraft> for Aircraft {
     fn try_from(packet: PbAircraft) -> Result<Self, Self::Error> {
         let icao_address = ICAOAddress::new(packet.icao_address)?;
         let ts = packet
-            .datetime
+            .broadcasted_timestamp
             .ok_or(AircraftConversionError::MissingDatetime)?;
         let sys_time = SystemTime::try_from(ts)?;
-        let datetime = DateTime::<Utc>::from(sys_time);
+        let broadcasted_timestamp = DateTime::<Utc>::from(sys_time);
 
         Ok(Self {
             callsign: packet.callsign,
             icao_address,
-            datetime,
+            broadcasted_timestamp,
             latitude: packet.latitude,
             longitude: packet.longitude,
             ground_track: packet.ground_track,
@@ -92,12 +92,12 @@ impl TryFrom<PbAircraft> for Aircraft {
 
 impl From<Aircraft> for PbAircraft {
     fn from(aircraft: Aircraft) -> Self {
-        let system_time = SystemTime::from(aircraft.datetime);
+        let system_time = SystemTime::from(aircraft.broadcasted_timestamp);
         let timestamp = prost_types::Timestamp::from(system_time);
         Self {
             callsign: aircraft.callsign,
             icao_address: aircraft.icao_address.value(),
-            datetime: Some(timestamp),
+            broadcasted_timestamp: Some(timestamp),
             latitude: aircraft.latitude,
             longitude: aircraft.longitude,
             ground_track: aircraft.ground_track,

--- a/src/parser/conversion.rs
+++ b/src/parser/conversion.rs
@@ -69,23 +69,23 @@ mod icao_serde {
 
 impl TryFrom<PbAircraft> for Aircraft {
     type Error = AircraftConversionError;
-    fn try_from(packet: PbAircraft) -> Result<Self, Self::Error> {
-        let icao_address = ICAOAddress::new(packet.icao_address)?;
-        let ts = packet
+    fn try_from(pb_aircraft: PbAircraft) -> Result<Self, Self::Error> {
+        let icao_address = ICAOAddress::new(pb_aircraft.icao_address)?;
+        let ts = pb_aircraft
             .broadcasted_timestamp
             .ok_or(AircraftConversionError::MissingDatetime)?;
         let sys_time = SystemTime::try_from(ts)?;
         let broadcasted_timestamp = DateTime::<Utc>::from(sys_time);
 
         Ok(Self {
-            callsign: packet.callsign,
+            callsign: pb_aircraft.callsign,
             icao_address,
             broadcasted_timestamp,
-            latitude: packet.latitude,
-            longitude: packet.longitude,
-            ground_track: packet.ground_track,
-            ground_speed: packet.ground_speed,
-            gps_altitude: packet.gps_altitude,
+            latitude: pb_aircraft.latitude,
+            longitude: pb_aircraft.longitude,
+            ground_track: pb_aircraft.ground_track,
+            ground_speed: pb_aircraft.ground_speed,
+            gps_altitude: pb_aircraft.gps_altitude,
         })
     }
 }

--- a/src/parser/conversion.rs
+++ b/src/parser/conversion.rs
@@ -22,19 +22,19 @@ pub struct Aircraft {
 
 pub fn convert_ogn_aprs_beacon_to_aircraft(
     aircraft_beacon: AircraftBeacon,
-    timestamp: std::time::SystemTime,
+    reference_packet_timestamp: DateTime<Utc>,
 ) -> Aircraft {
-    let now: chrono::DateTime<chrono::Utc> = timestamp.into();
-
-    let datetime = chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
-        now.date_naive().and_time(aircraft_beacon.time),
+    let broadcasted_timestamp = chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
+        reference_packet_timestamp
+            .date_naive()
+            .and_time(aircraft_beacon.time),
         chrono::Utc,
     );
 
     Aircraft {
         callsign: aircraft_beacon.callsign,
         icao_address: aircraft_beacon.ogn_beacon_id.icao_address,
-        broadcasted_timestamp: datetime,
+        broadcasted_timestamp,
         latitude: aircraft_beacon.latitude,
         longitude: aircraft_beacon.longitude,
         ground_track: aircraft_beacon.ground_track,

--- a/src/test_utilities.rs
+++ b/src/test_utilities.rs
@@ -27,13 +27,13 @@ pub fn test_data_path() -> std::path::PathBuf {
 }
 
 pub fn create_dummy_aircraft_at_time(
-    datetime: chrono::DateTime<chrono::Utc>,
+    timestamp: chrono::DateTime<chrono::Utc>,
     icao_address: ICAOAddress,
 ) -> Aircraft {
     Aircraft {
         callsign: String::from("dummy"),
         icao_address,
-        datetime,
+        broadcasted_timestamp: timestamp,
         latitude: 0.0,
         longitude: 0.0,
         ground_track: 0.0,


### PR DESCRIPTION
This PR standardizes the representation of timestamp within structs as `Datetime<Utc>`