### PR TITLE
Use `mcap` to log messages to disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,12 +502,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "binrw"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53195f985e88ab94d1cc87e80049dd2929fd39e4a772c5ae96a7e5c4aad3642"
+dependencies = [
+ "array-init",
+ "binrw_derive",
+ "bytemuck",
+]
+
+[[package]]
+name = "binrw_derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5910da05ee556b789032c8ff5a61fb99239580aa3fd0bfaa8f4d094b2aee00ad"
+dependencies = [
+ "either",
+ "owo-colors",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -593,6 +629,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
@@ -939,6 +981,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1095,12 @@ name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecolor"
@@ -1220,6 +1302,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumset"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,11 +1491,13 @@ dependencies = [
  "env_logger",
  "glob",
  "log",
+ "mcap",
  "ogn-aprs-parser",
  "prost",
  "prost-build",
  "prost-types",
  "rstest",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
@@ -1407,6 +1512,12 @@ name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -2092,6 +2203,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,6 +2486,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,6 +2520,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "mcap"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b215e79631de2a19ed76fda13cd52950c3057b487a2f41d9dc85c4079b969c40"
+dependencies = [
+ "bimap",
+ "binrw",
+ "byteorder",
+ "crc32fast",
+ "enumset",
+ "log",
+ "lz4",
+ "num_cpus",
+ "paste",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "zstd",
 ]
 
 [[package]]
@@ -2606,6 +2762,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2972,6 +3138,12 @@ checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking"
@@ -3473,6 +3645,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "reflink-copy"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3754,6 +3946,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3808,6 +4026,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6027,6 +6256,34 @@ name = "zmij"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1966f8ac2c1f76987d69a74d0e0f929241c10e78136434e3be70ff7f58f64214"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ toml = "0.9.8"
 walkers = "0.52.0"
 ogn-aprs-parser = "0.2.0"
 serde_json = "1.0.150"
+mcap = "0.25.0"
+schemars = { version = "1.2.1", features = ["chrono04"] }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/build.rs
+++ b/build.rs
@@ -20,6 +20,7 @@ fn main() -> Result<()> {
     let descriptor_path = out_dir.join("file_descriptor_set.bin");
 
     let mut config = prost_build::Config::new();
+    config.enable_type_names();
     config.bytes(["."]);
     config.file_descriptor_set_path(&descriptor_path);
     config.compile_protos(&proto_files, &["."])?;

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
 use glob::glob;
+use std::env;
 use std::io::Result;
+use std::path::PathBuf;
 
 fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=proto/");
@@ -14,8 +16,12 @@ fn main() -> Result<()> {
             Err(e) => println!("cargo:warning=Glob error: {e:?}"),
         }
     }
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let descriptor_path = out_dir.join("file_descriptor_set.bin");
+
     let mut config = prost_build::Config::new();
     config.bytes(["."]);
+    config.file_descriptor_set_path(&descriptor_path);
     config.compile_protos(&proto_files, &["."])?;
 
     Ok(())

--- a/pipeline.example.toml
+++ b/pipeline.example.toml
@@ -1,14 +1,14 @@
 [ingestor]
 # optional write path
-# write_path = "./data/ingestor.pb"
+# write_path = "./data/ingestor.mcap"
 
 [parser]
 # optional write path
-# write_path = "./data/parser.jsonl"
+# write_path = "./data/parser.mcap"
 
 [ingestor.source]
-# for reading from .pb log
-# read_path = "./data/ingestor.pb"
+# for reading from existing log
+# read_path = "./data/ingestor.mcap"
 
 # for reading from glidernet source
 host = "aprs.glidernet.org"

--- a/src/airspace/conversion.rs
+++ b/src/airspace/conversion.rs
@@ -1,7 +1,25 @@
+use std::convert::Infallible;
 use std::time::SystemTime;
 
 use crate::airspace::detail::AirspaceUpdate;
+use crate::core::central_disk_logger::interface::IntoLogMessage;
 use crate::pb::airspace::PbAirspaceUpdate;
+
+impl IntoLogMessage<PbAirspaceUpdate> for AirspaceUpdate {
+    type Error = Infallible;
+    fn message_timestamp(&self) -> chrono::prelude::DateTime<chrono::prelude::Utc> {
+        self.timestamp
+    }
+    fn into_message(self) -> Result<PbAirspaceUpdate, Self::Error> {
+        let sys_time: SystemTime = self.timestamp.into();
+        let timestamp = Some(sys_time.into());
+
+        Ok(PbAirspaceUpdate {
+            timestamp,
+            updates: self.updates.into_iter().map(Into::into).collect(),
+        })
+    }
+}
 
 impl From<AirspaceUpdate> for PbAirspaceUpdate {
     fn from(airspace_update: AirspaceUpdate) -> Self {

--- a/src/airspace/conversion.rs
+++ b/src/airspace/conversion.rs
@@ -2,7 +2,7 @@ use std::convert::Infallible;
 use std::time::SystemTime;
 
 use crate::airspace::detail::AirspaceUpdate;
-use crate::core::central_disk_logger::interface::IntoLogMessage;
+use crate::core::central_disk_logger::IntoLogMessage;
 use crate::pb::airspace::PbAirspaceUpdate;
 
 impl IntoLogMessage<PbAirspaceUpdate> for AirspaceUpdate {

--- a/src/core/central_disk_logger/errors.rs
+++ b/src/core/central_disk_logger/errors.rs
@@ -1,7 +1,7 @@
-use std::io;
 use std::path::PathBuf;
+use std::{convert::Infallible, io};
 
-use crate::core::central_disk_logger::interface::{DiskLoggerMessage, LoggerTaskID};
+use crate::core::central_disk_logger::interface::{ChannelID, DiskLoggerMessage};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProtoLoggingError<T> {
@@ -9,6 +9,11 @@ pub enum ProtoLoggingError<T> {
     Conversion(T),
     #[error("Failed to send: {0}")]
     SendError(#[from] crossbeam_channel::SendError<DiskLoggerMessage>),
+}
+impl<T> From<Infallible> for ProtoLoggingError<T> {
+    fn from(err: Infallible) -> Self {
+        match err {}
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -19,6 +24,11 @@ pub enum JsonLoggingError<T> {
     SendError(#[from] crossbeam_channel::SendError<DiskLoggerMessage>),
     #[error("Failed to send: {0}")]
     Serialization(#[from] serde_json::Error),
+}
+impl<T> From<std::convert::Infallible> for JsonLoggingError<T> {
+    fn from(err: std::convert::Infallible) -> Self {
+        match err {}
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -40,7 +50,7 @@ pub enum DiskloggerRegistryError {
 #[derive(Debug, thiserror::Error)]
 pub enum CentralDiskLoggerError {
     #[error("TaskID not registered: {0}")]
-    TaskNotRegistered(LoggerTaskID),
+    TaskNotRegistered(ChannelID),
 
     #[error("Unable to write data to log file: {path}")]
     WriteError {

--- a/src/core/central_disk_logger/errors.rs
+++ b/src/core/central_disk_logger/errors.rs
@@ -45,6 +45,9 @@ pub enum DiskloggerRegistryError {
         #[source]
         source: io::Error,
     },
+
+    #[error("Unable to create Mcap writer: {0}")]
+    WriterCreationError(#[from] mcap::McapError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -52,11 +55,6 @@ pub enum CentralDiskLoggerError {
     #[error("TaskID not registered: {0}")]
     TaskNotRegistered(LoggerID),
 
-    #[error("Unable to write data to log file: {path}")]
-    WriteError {
-        path: PathBuf,
-        payload: Vec<u8>,
-        #[source]
-        source: io::Error,
-    },
+    #[error("Unable to write data to log file: {0}")]
+    WriteError(#[from] mcap::McapError),
 }

--- a/src/core/central_disk_logger/errors.rs
+++ b/src/core/central_disk_logger/errors.rs
@@ -4,7 +4,15 @@ use std::path::PathBuf;
 use crate::core::central_disk_logger::interface::{DiskLoggerMessage, LoggerTaskID};
 
 #[derive(Debug, thiserror::Error)]
-pub enum LoggingError<T> {
+pub enum ProtoLoggingError<T> {
+    #[error("Packet Conversion Error: {0}")]
+    Conversion(T),
+    #[error("Failed to send: {0}")]
+    SendError(#[from] crossbeam_channel::SendError<DiskLoggerMessage>),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum JsonLoggingError<T> {
     #[error("Packet Conversion Error: {0}")]
     Conversion(T),
     #[error("Failed to send: {0}")]

--- a/src/core/central_disk_logger/errors.rs
+++ b/src/core/central_disk_logger/errors.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::{convert::Infallible, io};
 
-use crate::core::central_disk_logger::interface::{ChannelID, DiskLoggerMessage};
+use crate::core::central_disk_logger::interface::{DiskLoggerMessage, LoggerID};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProtoLoggingError<T> {
@@ -50,7 +50,7 @@ pub enum DiskloggerRegistryError {
 #[derive(Debug, thiserror::Error)]
 pub enum CentralDiskLoggerError {
     #[error("TaskID not registered: {0}")]
-    TaskNotRegistered(ChannelID),
+    TaskNotRegistered(LoggerID),
 
     #[error("Unable to write data to log file: {path}")]
     WriteError {

--- a/src/core/central_disk_logger/interface.rs
+++ b/src/core/central_disk_logger/interface.rs
@@ -12,29 +12,27 @@ use crate::core::central_disk_logger::{
 };
 use crate::ext::TryInsertExt;
 
-pub type ChannelID = u8;
+pub type LoggerID = u8;
 
 const PROTO_FILE_FORMAT: &str = "pb";
 const JSONL_FILE_FORMAT: &str = "jsonl";
+
 #[derive(Debug)]
 pub struct DiskLoggerMessage {
-    pub channel_id: ChannelID,
+    pub logger_id: LoggerID,
     pub publish_timestamp: DateTime<Utc>,
     pub payload: Vec<u8>,
 }
 
 #[derive(Debug)]
 pub struct LoggerHandle<F, M: ?Sized> {
-    channel_id: ChannelID,
+    channel_id: LoggerID,
     sender: crossbeam_channel::Sender<DiskLoggerMessage>,
     _marker: PhantomData<(F, M)>,
 }
 
 impl<F, M> LoggerHandle<F, M> {
-    pub fn new(
-        channel_id: ChannelID,
-        sender: crossbeam_channel::Sender<DiskLoggerMessage>,
-    ) -> Self {
+    pub fn new(channel_id: LoggerID, sender: crossbeam_channel::Sender<DiskLoggerMessage>) -> Self {
         Self {
             channel_id,
             sender,
@@ -42,7 +40,7 @@ impl<F, M> LoggerHandle<F, M> {
         }
     }
 
-    pub fn channel_id(&self) -> ChannelID {
+    pub fn channel_id(&self) -> LoggerID {
         self.channel_id
     }
 }
@@ -62,7 +60,7 @@ where
         let payload = proto_message.encode_length_delimited_to_vec();
 
         Ok(self.sender.send(DiskLoggerMessage {
-            channel_id: self.channel_id,
+            logger_id: self.channel_id,
             publish_timestamp,
             payload,
         })?)
@@ -88,7 +86,7 @@ where
 
         self.sender
             .send(DiskLoggerMessage {
-                channel_id: self.channel_id,
+                logger_id: self.channel_id,
                 publish_timestamp,
                 payload,
             })
@@ -100,10 +98,10 @@ where
 
 #[derive(Debug)]
 pub struct DiskLoggerRegistry {
-    current_logger_id: ChannelID,
+    current_logger_id: LoggerID,
     sender: crossbeam_channel::Sender<DiskLoggerMessage>,
     receiver: crossbeam_channel::Receiver<DiskLoggerMessage>,
-    task_to_path_mapping: HashMap<ChannelID, (PathBuf, BufWriter<File>)>,
+    task_to_path_mapping: HashMap<LoggerID, (PathBuf, BufWriter<File>)>,
 }
 impl DiskLoggerRegistry {
     pub fn new() -> Self {

--- a/src/core/central_disk_logger/interface.rs
+++ b/src/core/central_disk_logger/interface.rs
@@ -9,8 +9,10 @@ use chrono::{DateTime, Utc};
 use crate::core::central_disk_logger::errors::{
     DiskloggerRegistryError, JsonLoggingError, ProtoLoggingError,
 };
-use crate::core::central_disk_logger::traits::{JsonToMcapSchema, ProtoToMcapSchema};
-use crate::core::central_disk_logger::{CentralDiskLogger, IntoLogMessage, LogSender};
+use crate::core::central_disk_logger::task::{CentralDiskLogger, WriteTarget};
+use crate::core::central_disk_logger::traits::{
+    IntoLogMessage, JsonToMcapSchema, LogSender, ProtoToMcapSchema,
+};
 use crate::ext::TryInsertExt;
 
 pub type LoggerID = u8;
@@ -102,7 +104,7 @@ pub struct DiskLoggerRegistry {
     current_logger_id: LoggerID,
     sender: crossbeam_channel::Sender<DiskLoggerMessage>,
     receiver: crossbeam_channel::Receiver<DiskLoggerMessage>,
-    task_to_path_mapping: HashMap<LoggerID, (PathBuf, BufWriter<File>)>,
+    id_to_target_mapping: HashMap<LoggerID, WriteTarget>,
 }
 impl DiskLoggerRegistry {
     pub fn new() -> Self {
@@ -111,7 +113,7 @@ impl DiskLoggerRegistry {
             current_logger_id: 0,
             sender,
             receiver,
-            task_to_path_mapping: HashMap::new(),
+            id_to_target_mapping: HashMap::new(),
         }
     }
 
@@ -136,7 +138,7 @@ impl DiskLoggerRegistry {
     }
 
     pub fn build(self) -> CentralDiskLogger {
-        CentralDiskLogger::new(self.receiver, self.task_to_path_mapping)
+        CentralDiskLogger::new(self.receiver, self.id_to_target_mapping)
     }
 
     fn register<F, M>(
@@ -152,11 +154,15 @@ impl DiskLoggerRegistry {
         let writer = BufWriter::new(file);
 
         let logger_id = self.current_logger_id;
-        let _ = TryInsertExt::try_insert(&mut self.task_to_path_mapping, logger_id, (path, writer))
-            .map_err(|err| {
-                let (rejected_path, _rejected_writer) = err.value;
-                DiskloggerRegistryError::PathAlreadyRegisteredError(rejected_path)
-            })?;
+        let _ = TryInsertExt::try_insert(
+            &mut self.id_to_target_mapping,
+            logger_id,
+            WriteTarget { path, writer },
+        )
+        .map_err(|err| {
+            let target = err.value;
+            DiskloggerRegistryError::PathAlreadyRegisteredError(target.path)
+        })?;
 
         let handle = LoggerHandle {
             logger_id,

--- a/src/core/central_disk_logger/interface.rs
+++ b/src/core/central_disk_logger/interface.rs
@@ -12,77 +12,85 @@ use crate::core::central_disk_logger::errors::{
 use crate::core::central_disk_logger::task::CentralDiskLogger;
 use crate::ext::TryInsertExt;
 
-pub type LoggerTaskID = u8;
+pub type ChannelID = u8;
 
 const PROTO_FILE_FORMAT: &str = "pb";
 const JSONL_FILE_FORMAT: &str = "jsonl";
 #[derive(Debug)]
 pub struct DiskLoggerMessage {
-    pub logger_id: LoggerTaskID,
+    pub channel_id: ChannelID,
+    pub publish_timestamp: DateTime<Utc>,
     pub payload: Vec<u8>,
 }
 
-pub trait LogSender<Input> {
+pub trait LogSender<M> {
     type Error;
-    fn send(&self, message: Input) -> Result<(), Self::Error>;
+    fn send(&self, message: M) -> Result<(), Self::Error>;
 }
 
-pub trait AsProtoMessage<T> {
-    fn proto_message(self) -> Result<impl prost::Message, ProtoLoggingError<T>>;
+pub trait IntoLogMessage<M> {
+    type Error;
+    fn into_message(self) -> Result<M, Self::Error>;
     fn message_timestamp(&self) -> DateTime<Utc>;
 }
+
 #[derive(Debug)]
 pub struct LoggerHandle<F, M: ?Sized> {
-    logger_id: LoggerTaskID,
+    channel_id: ChannelID,
     sender: crossbeam_channel::Sender<DiskLoggerMessage>,
     _marker: PhantomData<(F, M)>,
 }
 
 impl<F, M> LoggerHandle<F, M> {
     pub fn new(
-        logger_id: LoggerTaskID,
+        channel_id: ChannelID,
         sender: crossbeam_channel::Sender<DiskLoggerMessage>,
     ) -> Self {
         Self {
-            logger_id,
+            channel_id,
             sender,
             _marker: PhantomData,
         }
     }
 
-    pub fn logger_id(&self) -> LoggerTaskID {
-        self.logger_id
+    pub fn channel_id(&self) -> ChannelID {
+        self.channel_id
     }
 }
 
-impl<M, T, E> LogSender<T> for LoggerHandle<ProtoFormat, M>
+impl<M, T> LogSender<T> for LoggerHandle<ProtoFormat, M>
 where
-    T: TryInto<M, Error = E>,
+    T: IntoLogMessage<M>,
     M: prost::Message,
+    ProtoLoggingError<T>: From<T::Error>,
 {
-    type Error = ProtoLoggingError<E>;
+    type Error = ProtoLoggingError<T>;
 
-    fn send(&self, message: T) -> Result<(), Self::Error> {
-        let proto_message: M = message.try_into().map_err(ProtoLoggingError::Conversion)?;
+    fn send(&self, message: T) -> Result<(), ProtoLoggingError<T>> {
+        let publish_timestamp = message.message_timestamp();
+        let proto_message: M = message.into_message()?;
 
         let payload = proto_message.encode_length_delimited_to_vec();
 
         Ok(self.sender.send(DiskLoggerMessage {
-            logger_id: self.logger_id,
+            channel_id: self.channel_id,
+            publish_timestamp,
             payload,
         })?)
     }
 }
 
-impl<M, T, E> LogSender<T> for LoggerHandle<JsonlFormat, M>
+impl<M, T> LogSender<T> for LoggerHandle<JsonlFormat, M>
 where
-    T: TryInto<M, Error = E>,
+    T: IntoLogMessage<M>,
     M: serde::Serialize,
+    JsonLoggingError<T>: From<T::Error>,
 {
-    type Error = JsonLoggingError<E>;
+    type Error = JsonLoggingError<T>;
 
-    fn send(&self, message: T) -> Result<(), Self::Error> {
-        let json_message: M = message.try_into().map_err(JsonLoggingError::Conversion)?;
+    fn send(&self, message: T) -> Result<(), JsonLoggingError<T>> {
+        let publish_timestamp = message.message_timestamp();
+        let json_message: M = message.into_message()?;
 
         let mut payload =
             serde_json::to_vec(&json_message).map_err(JsonLoggingError::Serialization)?;
@@ -91,7 +99,8 @@ where
 
         self.sender
             .send(DiskLoggerMessage {
-                logger_id: self.logger_id,
+                channel_id: self.channel_id,
+                publish_timestamp,
                 payload,
             })
             .map_err(JsonLoggingError::SendError)?;
@@ -102,10 +111,10 @@ where
 
 #[derive(Debug)]
 pub struct DiskLoggerRegistry {
-    current_logger_id: LoggerTaskID,
+    current_logger_id: ChannelID,
     sender: crossbeam_channel::Sender<DiskLoggerMessage>,
     receiver: crossbeam_channel::Receiver<DiskLoggerMessage>,
-    task_to_path_mapping: HashMap<LoggerTaskID, (PathBuf, BufWriter<File>)>,
+    task_to_path_mapping: HashMap<ChannelID, (PathBuf, BufWriter<File>)>,
 }
 impl DiskLoggerRegistry {
     pub fn new() -> Self {
@@ -162,7 +171,7 @@ impl DiskLoggerRegistry {
             })?;
 
         let handle = LoggerHandle {
-            logger_id,
+            channel_id: logger_id,
             sender: self.sender.clone(),
             _marker: PhantomData,
         };
@@ -215,7 +224,7 @@ mod tests {
             let res = handler.send(message);
             assert!(matches!(
                 res.err().unwrap(),
-                ProtoLoggingError::Conversion(MockConversionError)
+                ProtoLoggingError::Conversion(_message)
             ));
             assert!(receiver.try_recv().is_err());
         }

--- a/src/core/central_disk_logger/interface.rs
+++ b/src/core/central_disk_logger/interface.rs
@@ -6,10 +6,10 @@ use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 
-use crate::core::central_disk_logger::errors::{
-    DiskloggerRegistryError, JsonLoggingError, ProtoLoggingError,
+use crate::core::central_disk_logger::{
+    CentralDiskLogger, DiskloggerRegistryError, IntoLogMessage, JsonLoggingError, LogSender,
+    ProtoLoggingError,
 };
-use crate::core::central_disk_logger::task::CentralDiskLogger;
 use crate::ext::TryInsertExt;
 
 pub type ChannelID = u8;
@@ -21,17 +21,6 @@ pub struct DiskLoggerMessage {
     pub channel_id: ChannelID,
     pub publish_timestamp: DateTime<Utc>,
     pub payload: Vec<u8>,
-}
-
-pub trait LogSender<M> {
-    type Error;
-    fn send(&self, message: M) -> Result<(), Self::Error>;
-}
-
-pub trait IntoLogMessage<M> {
-    type Error;
-    fn into_message(self) -> Result<M, Self::Error>;
-    fn message_timestamp(&self) -> DateTime<Utc>;
 }
 
 #[derive(Debug)]

--- a/src/core/central_disk_logger/interface.rs
+++ b/src/core/central_disk_logger/interface.rs
@@ -1,8 +1,9 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
 use std::io::BufWriter;
 use std::marker::PhantomData;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 
@@ -17,8 +18,7 @@ use crate::ext::TryInsertExt;
 
 pub type LoggerID = u8;
 
-const PROTO_FILE_FORMAT: &str = "pb";
-const JSONL_FILE_FORMAT: &str = "jsonl";
+const MCAP_FILE_SUFFIX: &str = "mcap";
 
 #[derive(Debug)]
 pub struct DiskLoggerMessage {
@@ -82,10 +82,7 @@ where
         let publish_timestamp = message.message_timestamp();
         let json_message: M = message.into_message()?;
 
-        let mut payload =
-            serde_json::to_vec(&json_message).map_err(JsonLoggingError::Serialization)?;
-
-        payload.push(b'\n');
+        let payload = serde_json::to_vec(&json_message).map_err(JsonLoggingError::Serialization)?;
 
         self.sender
             .send(DiskLoggerMessage {
@@ -99,7 +96,6 @@ where
     }
 }
 
-#[derive(Debug)]
 pub struct DiskLoggerRegistry {
     current_logger_id: LoggerID,
     sender: crossbeam_channel::Sender<DiskLoggerMessage>,
@@ -117,24 +113,45 @@ impl DiskLoggerRegistry {
         }
     }
 
-    pub fn register_proto<M>(
+    pub fn register_proto<M: ProtoToMcapSchema>(
         &mut self,
         path: PathBuf,
+        topic: String,
     ) -> Result<LoggerHandle<ProtoFormat, M>, DiskloggerRegistryError> {
-        if path.extension().is_none_or(|ext| ext != PROTO_FILE_FORMAT) {
+        if path.extension().is_none_or(|ext| ext != MCAP_FILE_SUFFIX) {
             return Err(DiskloggerRegistryError::InvalidPath(path));
         }
-        self.register::<ProtoFormat, M>(path)
+        let schema = M::translate_schema();
+        let channel = Arc::new(mcap::Channel {
+            id: 0,
+            topic,
+            schema: Some(Arc::new(schema)),
+            message_encoding: "protobuf".to_string(),
+            metadata: BTreeMap::new(),
+        });
+        self.register::<ProtoFormat, M>(path, channel)
     }
 
-    pub fn register_jsonl<M>(
+    pub fn register_jsonl<M: JsonToMcapSchema>(
         &mut self,
         path: PathBuf,
+        topic: String,
     ) -> Result<LoggerHandle<JsonFormat, M>, DiskloggerRegistryError> {
-        if path.extension().is_none_or(|ext| ext != JSONL_FILE_FORMAT) {
+        if path.extension().is_none_or(|ext| ext != MCAP_FILE_SUFFIX) {
             return Err(DiskloggerRegistryError::InvalidPath(path));
         }
-        self.register::<JsonFormat, M>(path)
+
+        let schema = M::translate_schema();
+
+        let channel = Arc::new(mcap::Channel {
+            id: 0,
+            topic,
+            schema: Some(Arc::new(schema)),
+            message_encoding: "json".to_string(),
+            metadata: BTreeMap::new(),
+        });
+
+        self.register::<JsonFormat, M>(path, channel)
     }
 
     pub fn build(self) -> CentralDiskLogger {
@@ -144,20 +161,27 @@ impl DiskLoggerRegistry {
     fn register<F, M>(
         &mut self,
         path: PathBuf,
+        channel: Arc<mcap::Channel<'static>>,
     ) -> Result<LoggerHandle<F, M>, DiskloggerRegistryError> {
-        let file = match File::create_new(&path) {
-            Ok(f) => f,
-            Err(err) => {
-                return Err(DiskloggerRegistryError::LogFileCreationError { path, source: err });
+        let file = File::create_new(&path).map_err(|err| {
+            DiskloggerRegistryError::LogFileCreationError {
+                path: path.clone(),
+                source: err,
             }
-        };
-        let writer = BufWriter::new(file);
+        })?;
+        let writer = mcap::Writer::new(BufWriter::new(file))
+            .map_err(DiskloggerRegistryError::WriterCreationError)?;
 
         let logger_id = self.current_logger_id;
+
         let _ = TryInsertExt::try_insert(
             &mut self.id_to_target_mapping,
             logger_id,
-            WriteTarget { path, writer },
+            WriteTarget {
+                path,
+                writer,
+                channel,
+            },
         )
         .map_err(|err| {
             let target = err.value;
@@ -241,10 +265,19 @@ mod tests {
         #[test]
         fn given_valid_paths_when_creating_logger_then_files_are_created() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let file_path = temp_dir.path().join("test_log_1.bin");
+            let file_path = temp_dir.path().join("test_log_1.mcap");
+
+            let channel = Arc::new(mcap::Channel {
+                id: 0,
+                topic: "test".to_string(),
+                schema: Some(Arc::new(MockTaskProto::translate_schema())),
+                message_encoding: "protobuf".to_string(),
+                metadata: BTreeMap::new(),
+            });
 
             let mut registry = DiskLoggerRegistry::new();
-            let handle = registry.register::<ProtoFormat, MockTaskProto>(file_path.clone());
+            let handle =
+                registry.register::<ProtoFormat, MockTaskProto>(file_path.clone(), channel);
             assert!(handle.is_ok());
             assert!(file_path.exists());
         }
@@ -255,8 +288,17 @@ mod tests {
             let file_path = temp_dir.path().join("already_exists.bin");
             fs::File::create(&file_path).unwrap();
 
+            let channel = Arc::new(mcap::Channel {
+                id: 0,
+                topic: "test".to_string(),
+                schema: Some(Arc::new(MockTaskProto::translate_schema())),
+                message_encoding: "protobuf".to_string(),
+                metadata: BTreeMap::new(),
+            });
+
             let mut register = DiskLoggerRegistry::new();
-            let handle = register.register::<ProtoFormat, MockTaskProto>(file_path.clone());
+            let handle =
+                register.register::<ProtoFormat, MockTaskProto>(file_path.clone(), channel);
 
             assert!(handle.is_err());
         }

--- a/src/core/central_disk_logger/interface.rs
+++ b/src/core/central_disk_logger/interface.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 
-use crate::core::central_disk_logger::traits::McapSchemaDescriptor;
+use crate::core::central_disk_logger::traits::{JsonToMcapSchema, ProtoToMcapSchema};
 use crate::core::central_disk_logger::{
     CentralDiskLogger, DiskloggerRegistryError, IntoLogMessage, JsonLoggingError, LogSender,
     ProtoLoggingError,
@@ -49,7 +49,7 @@ impl<F, M> LoggerHandle<F, M> {
 impl<M, T> LogSender<T> for LoggerHandle<ProtoFormat, M>
 where
     T: IntoLogMessage<M>,
-    M: prost::Message + McapSchemaDescriptor,
+    M: prost::Message + ProtoToMcapSchema,
     ProtoLoggingError<T>: From<T::Error>,
 {
     type Error = ProtoLoggingError<T>;
@@ -71,7 +71,7 @@ where
 impl<M, T> LogSender<T> for LoggerHandle<JsonFormat, M>
 where
     T: IntoLogMessage<M>,
-    M: serde::Serialize + McapSchemaDescriptor,
+    M: serde::Serialize + JsonToMcapSchema,
     JsonLoggingError<T>: From<T::Error>,
 {
     type Error = JsonLoggingError<T>;

--- a/src/core/central_disk_logger/interface.rs
+++ b/src/core/central_disk_logger/interface.rs
@@ -4,7 +4,11 @@ use std::io::BufWriter;
 use std::marker::PhantomData;
 use std::path::PathBuf;
 
-use crate::core::central_disk_logger::errors;
+use chrono::{DateTime, Utc};
+
+use crate::core::central_disk_logger::errors::{
+    DiskloggerRegistryError, JsonLoggingError, ProtoLoggingError,
+};
 use crate::core::central_disk_logger::task::CentralDiskLogger;
 use crate::ext::TryInsertExt;
 
@@ -21,6 +25,11 @@ pub struct DiskLoggerMessage {
 pub trait LogSender<Input> {
     type Error;
     fn send(&self, message: Input) -> Result<(), Self::Error>;
+}
+
+pub trait AsProtoMessage<T> {
+    fn proto_message(self) -> Result<impl prost::Message, ProtoLoggingError<T>>;
+    fn message_timestamp(&self) -> DateTime<Utc>;
 }
 #[derive(Debug)]
 pub struct LoggerHandle<F, M: ?Sized> {
@@ -51,12 +60,10 @@ where
     T: TryInto<M, Error = E>,
     M: prost::Message,
 {
-    type Error = errors::LoggingError<E>;
+    type Error = ProtoLoggingError<E>;
 
     fn send(&self, message: T) -> Result<(), Self::Error> {
-        let proto_message: M = message
-            .try_into()
-            .map_err(errors::LoggingError::Conversion)?;
+        let proto_message: M = message.try_into().map_err(ProtoLoggingError::Conversion)?;
 
         let payload = proto_message.encode_length_delimited_to_vec();
 
@@ -72,15 +79,13 @@ where
     T: TryInto<M, Error = E>,
     M: serde::Serialize,
 {
-    type Error = errors::LoggingError<E>;
+    type Error = JsonLoggingError<E>;
 
     fn send(&self, message: T) -> Result<(), Self::Error> {
-        let json_message: M = message
-            .try_into()
-            .map_err(errors::LoggingError::Conversion)?;
+        let json_message: M = message.try_into().map_err(JsonLoggingError::Conversion)?;
 
         let mut payload =
-            serde_json::to_vec(&json_message).map_err(errors::LoggingError::Serialization)?;
+            serde_json::to_vec(&json_message).map_err(JsonLoggingError::Serialization)?;
 
         payload.push(b'\n');
 
@@ -89,7 +94,7 @@ where
                 logger_id: self.logger_id,
                 payload,
             })
-            .map_err(errors::LoggingError::SendError)?;
+            .map_err(JsonLoggingError::SendError)?;
 
         Ok(())
     }
@@ -116,9 +121,9 @@ impl DiskLoggerRegistry {
     pub fn register_proto<M>(
         &mut self,
         path: PathBuf,
-    ) -> Result<LoggerHandle<ProtoFormat, M>, errors::DiskloggerRegistryError> {
+    ) -> Result<LoggerHandle<ProtoFormat, M>, DiskloggerRegistryError> {
         if path.extension().is_none_or(|ext| ext != PROTO_FILE_FORMAT) {
-            return Err(errors::DiskloggerRegistryError::InvalidPath(path));
+            return Err(DiskloggerRegistryError::InvalidPath(path));
         }
         self.register::<ProtoFormat, M>(path)
     }
@@ -126,9 +131,9 @@ impl DiskLoggerRegistry {
     pub fn register_jsonl<M>(
         &mut self,
         path: PathBuf,
-    ) -> Result<LoggerHandle<JsonlFormat, M>, errors::DiskloggerRegistryError> {
+    ) -> Result<LoggerHandle<JsonlFormat, M>, DiskloggerRegistryError> {
         if path.extension().is_none_or(|ext| ext != JSONL_FILE_FORMAT) {
-            return Err(errors::DiskloggerRegistryError::InvalidPath(path));
+            return Err(DiskloggerRegistryError::InvalidPath(path));
         }
         self.register::<JsonlFormat, M>(path)
     }
@@ -140,14 +145,11 @@ impl DiskLoggerRegistry {
     fn register<F, M>(
         &mut self,
         path: PathBuf,
-    ) -> Result<LoggerHandle<F, M>, errors::DiskloggerRegistryError> {
+    ) -> Result<LoggerHandle<F, M>, DiskloggerRegistryError> {
         let file = match File::create_new(&path) {
             Ok(f) => f,
             Err(err) => {
-                return Err(errors::DiskloggerRegistryError::LogFileCreationError {
-                    path,
-                    source: err,
-                });
+                return Err(DiskloggerRegistryError::LogFileCreationError { path, source: err });
             }
         };
         let writer = BufWriter::new(file);
@@ -156,7 +158,7 @@ impl DiskLoggerRegistry {
         let _ = TryInsertExt::try_insert(&mut self.task_to_path_mapping, logger_id, (path, writer))
             .map_err(|err| {
                 let (rejected_path, _rejected_writer) = err.value;
-                errors::DiskloggerRegistryError::PathAlreadyRegisteredError(rejected_path)
+                DiskloggerRegistryError::PathAlreadyRegisteredError(rejected_path)
             })?;
 
         let handle = LoggerHandle {
@@ -213,7 +215,7 @@ mod tests {
             let res = handler.send(message);
             assert!(matches!(
                 res.err().unwrap(),
-                errors::LoggingError::Conversion(MockConversionError)
+                ProtoLoggingError::Conversion(MockConversionError)
             ));
             assert!(receiver.try_recv().is_err());
         }
@@ -226,10 +228,7 @@ mod tests {
             let handler = LoggerHandle::<ProtoFormat, MockTaskProto>::new(1, sender);
             drop(receiver);
             let res = handler.send(message);
-            assert!(matches!(
-                res.unwrap_err(),
-                errors::LoggingError::SendError(_)
-            ));
+            assert!(matches!(res.unwrap_err(), ProtoLoggingError::SendError(_)));
         }
     }
 

--- a/src/core/central_disk_logger/interface.rs
+++ b/src/core/central_disk_logger/interface.rs
@@ -26,22 +26,22 @@ pub struct DiskLoggerMessage {
 
 #[derive(Debug)]
 pub struct LoggerHandle<F, M: ?Sized> {
-    channel_id: LoggerID,
+    logger_id: LoggerID,
     sender: crossbeam_channel::Sender<DiskLoggerMessage>,
     _marker: PhantomData<(F, M)>,
 }
 
 impl<F, M> LoggerHandle<F, M> {
-    pub fn new(channel_id: LoggerID, sender: crossbeam_channel::Sender<DiskLoggerMessage>) -> Self {
+    pub fn new(logger_id: LoggerID, sender: crossbeam_channel::Sender<DiskLoggerMessage>) -> Self {
         Self {
-            channel_id,
+            logger_id,
             sender,
             _marker: PhantomData,
         }
     }
 
-    pub fn channel_id(&self) -> LoggerID {
-        self.channel_id
+    pub fn logger_id(&self) -> LoggerID {
+        self.logger_id
     }
 }
 
@@ -60,7 +60,7 @@ where
         let payload = proto_message.encode_length_delimited_to_vec();
 
         Ok(self.sender.send(DiskLoggerMessage {
-            logger_id: self.channel_id,
+            logger_id: self.logger_id,
             publish_timestamp,
             payload,
         })?)
@@ -86,7 +86,7 @@ where
 
         self.sender
             .send(DiskLoggerMessage {
-                logger_id: self.channel_id,
+                logger_id: self.logger_id,
                 publish_timestamp,
                 payload,
             })
@@ -158,7 +158,7 @@ impl DiskLoggerRegistry {
             })?;
 
         let handle = LoggerHandle {
-            channel_id: logger_id,
+            logger_id,
             sender: self.sender.clone(),
             _marker: PhantomData,
         };

--- a/src/core/central_disk_logger/interface.rs
+++ b/src/core/central_disk_logger/interface.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 
+use crate::core::central_disk_logger::traits::McapSchemaDescriptor;
 use crate::core::central_disk_logger::{
     CentralDiskLogger, DiskloggerRegistryError, IntoLogMessage, JsonLoggingError, LogSender,
     ProtoLoggingError,
@@ -48,7 +49,7 @@ impl<F, M> LoggerHandle<F, M> {
 impl<M, T> LogSender<T> for LoggerHandle<ProtoFormat, M>
 where
     T: IntoLogMessage<M>,
-    M: prost::Message,
+    M: prost::Message + McapSchemaDescriptor,
     ProtoLoggingError<T>: From<T::Error>,
 {
     type Error = ProtoLoggingError<T>;
@@ -67,10 +68,10 @@ where
     }
 }
 
-impl<M, T> LogSender<T> for LoggerHandle<JsonlFormat, M>
+impl<M, T> LogSender<T> for LoggerHandle<JsonFormat, M>
 where
     T: IntoLogMessage<M>,
-    M: serde::Serialize,
+    M: serde::Serialize + McapSchemaDescriptor,
     JsonLoggingError<T>: From<T::Error>,
 {
     type Error = JsonLoggingError<T>;
@@ -127,11 +128,11 @@ impl DiskLoggerRegistry {
     pub fn register_jsonl<M>(
         &mut self,
         path: PathBuf,
-    ) -> Result<LoggerHandle<JsonlFormat, M>, DiskloggerRegistryError> {
+    ) -> Result<LoggerHandle<JsonFormat, M>, DiskloggerRegistryError> {
         if path.extension().is_none_or(|ext| ext != JSONL_FILE_FORMAT) {
             return Err(DiskloggerRegistryError::InvalidPath(path));
         }
-        self.register::<JsonlFormat, M>(path)
+        self.register::<JsonFormat, M>(path)
     }
 
     pub fn build(self) -> CentralDiskLogger {
@@ -173,11 +174,11 @@ impl Default for DiskLoggerRegistry {
     }
 }
 
-pub struct JsonlFormat {}
-pub struct ProtoFormat {}
+pub struct JsonFormat;
+pub struct ProtoFormat;
 
 pub type ProtoLoggerHandle<M> = LoggerHandle<ProtoFormat, M>;
-pub type JsonlLoggerHandle<M> = LoggerHandle<JsonlFormat, M>;
+pub type JsonlLoggerHandle<M> = LoggerHandle<JsonFormat, M>;
 
 #[cfg(test)]
 mod tests {

--- a/src/core/central_disk_logger/interface.rs
+++ b/src/core/central_disk_logger/interface.rs
@@ -18,16 +18,15 @@ pub struct DiskLoggerMessage {
     pub payload: Vec<u8>,
 }
 
+pub trait LogSender<Input> {
+    type Error;
+    fn send(&self, message: Input) -> Result<(), Self::Error>;
+}
 #[derive(Debug)]
 pub struct LoggerHandle<F, M: ?Sized> {
     logger_id: LoggerTaskID,
     sender: crossbeam_channel::Sender<DiskLoggerMessage>,
     _marker: PhantomData<(F, M)>,
-}
-
-pub trait LogSender<Input> {
-    type Error;
-    fn send(&self, message: Input) -> Result<(), Self::Error>;
 }
 
 impl<F, M> LoggerHandle<F, M> {

--- a/src/core/central_disk_logger/interface.rs
+++ b/src/core/central_disk_logger/interface.rs
@@ -6,11 +6,11 @@ use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 
-use crate::core::central_disk_logger::traits::{JsonToMcapSchema, ProtoToMcapSchema};
-use crate::core::central_disk_logger::{
-    CentralDiskLogger, DiskloggerRegistryError, IntoLogMessage, JsonLoggingError, LogSender,
-    ProtoLoggingError,
+use crate::core::central_disk_logger::errors::{
+    DiskloggerRegistryError, JsonLoggingError, ProtoLoggingError,
 };
+use crate::core::central_disk_logger::traits::{JsonToMcapSchema, ProtoToMcapSchema};
+use crate::core::central_disk_logger::{CentralDiskLogger, IntoLogMessage, LogSender};
 use crate::ext::TryInsertExt;
 
 pub type LoggerID = u8;

--- a/src/core/central_disk_logger/mod.rs
+++ b/src/core/central_disk_logger/mod.rs
@@ -13,4 +13,4 @@ pub use interface::{
     DiskLoggerMessage, DiskLoggerRegistry, JsonlLoggerHandle, LoggerID, ProtoLoggerHandle,
 };
 pub use task::CentralDiskLogger;
-pub use traits::{IntoLogMessage, LogSender, McapSchemaDescriptor};
+pub use traits::{IntoLogMessage, LogSender, ProtoToMcapSchema};

--- a/src/core/central_disk_logger/mod.rs
+++ b/src/core/central_disk_logger/mod.rs
@@ -1,14 +1,11 @@
 pub mod errors;
-pub mod interface;
-pub mod task;
-pub mod traits;
+mod interface;
+mod task;
+mod traits;
 
 #[cfg(test)]
-pub mod testing;
+mod testing;
 
-pub use errors::{
-    CentralDiskLoggerError, DiskloggerRegistryError, JsonLoggingError, ProtoLoggingError,
-};
 pub use interface::{
     DiskLoggerMessage, DiskLoggerRegistry, JsonlLoggerHandle, LoggerID, ProtoLoggerHandle,
 };

--- a/src/core/central_disk_logger/mod.rs
+++ b/src/core/central_disk_logger/mod.rs
@@ -1,12 +1,16 @@
 pub mod errors;
 pub mod interface;
 pub mod task;
+pub mod traits;
 
 #[cfg(test)]
 pub mod testing;
 
+pub use errors::{
+    CentralDiskLoggerError, DiskloggerRegistryError, JsonLoggingError, ProtoLoggingError,
+};
 pub use interface::{
-    ChannelID, DiskLoggerMessage, DiskLoggerRegistry, JsonlLoggerHandle, LogSender,
-    ProtoLoggerHandle,
+    ChannelID, DiskLoggerMessage, DiskLoggerRegistry, JsonlLoggerHandle, ProtoLoggerHandle,
 };
 pub use task::CentralDiskLogger;
+pub use traits::{IntoLogMessage, LogSender};

--- a/src/core/central_disk_logger/mod.rs
+++ b/src/core/central_disk_logger/mod.rs
@@ -10,7 +10,7 @@ pub use errors::{
     CentralDiskLoggerError, DiskloggerRegistryError, JsonLoggingError, ProtoLoggingError,
 };
 pub use interface::{
-    ChannelID, DiskLoggerMessage, DiskLoggerRegistry, JsonlLoggerHandle, ProtoLoggerHandle,
+    DiskLoggerMessage, DiskLoggerRegistry, JsonlLoggerHandle, LoggerID, ProtoLoggerHandle,
 };
 pub use task::CentralDiskLogger;
 pub use traits::{IntoLogMessage, LogSender};

--- a/src/core/central_disk_logger/mod.rs
+++ b/src/core/central_disk_logger/mod.rs
@@ -13,4 +13,4 @@ pub use interface::{
     DiskLoggerMessage, DiskLoggerRegistry, JsonlLoggerHandle, LoggerID, ProtoLoggerHandle,
 };
 pub use task::CentralDiskLogger;
-pub use traits::{IntoLogMessage, LogSender};
+pub use traits::{IntoLogMessage, LogSender, McapSchemaDescriptor};

--- a/src/core/central_disk_logger/mod.rs
+++ b/src/core/central_disk_logger/mod.rs
@@ -6,7 +6,7 @@ pub mod task;
 pub mod testing;
 
 pub use interface::{
-    DiskLoggerMessage, DiskLoggerRegistry, JsonlLoggerHandle, LogSender, LoggerTaskID,
+    ChannelID, DiskLoggerMessage, DiskLoggerRegistry, JsonlLoggerHandle, LogSender,
     ProtoLoggerHandle,
 };
 pub use task::CentralDiskLogger;

--- a/src/core/central_disk_logger/task.rs
+++ b/src/core/central_disk_logger/task.rs
@@ -1,16 +1,17 @@
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{BufWriter, Write};
+use std::io::BufWriter;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::core::central_disk_logger::errors;
 use crate::core::central_disk_logger::interface::{DiskLoggerMessage, LoggerID};
 use crate::core::thread_manager::{SteppableTask, TaskState};
 
-#[derive(Debug)]
 pub struct WriteTarget {
     pub path: PathBuf,
-    pub writer: BufWriter<File>,
+    pub writer: mcap::Writer<BufWriter<File>>,
+    pub channel: Arc<mcap::Channel<'static>>,
 }
 pub struct CentralDiskLogger {
     receiver: crossbeam_channel::Receiver<DiskLoggerMessage>,
@@ -36,14 +37,22 @@ impl SteppableTask for CentralDiskLogger {
                     errors::CentralDiskLoggerError::TaskNotRegistered(message.logger_id),
                 ) {
                     Ok(target) => {
-                        let _ = target.writer.write_all(&message.payload).map_err(|err| {
-                            let write_error = errors::CentralDiskLoggerError::WriteError {
-                                path: target.path.clone(),
-                                payload: message.payload,
-                                source: err,
-                            };
-                            log::warn!("{write_error}")
-                        });
+                        let mcap_message = mcap::Message {
+                            channel: target.channel.clone(),
+                            sequence: 0,
+                            log_time: message.publish_timestamp.timestamp_nanos_opt().unwrap()
+                                as u64,
+                            publish_time: message.publish_timestamp.timestamp_nanos_opt().unwrap()
+                                as u64,
+                            data: message.payload.into(),
+                        };
+                        if let Err(err) = target
+                            .writer
+                            .write(&mcap_message)
+                            .map_err(errors::CentralDiskLoggerError::WriteError)
+                        {
+                            log::warn!("{err}")
+                        }
                     }
                     Err(err) => log::warn!("{err}"),
                 };
@@ -54,12 +63,19 @@ impl SteppableTask for CentralDiskLogger {
         }
     }
 }
+
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use chrono::Utc;
+    use prost::Message;
+
+    use crate::core::central_disk_logger::{
+        ProtoToMcapSchema, testing::test_helpers::MockTaskProto,
+    };
 
     use super::*;
-    use std::fs;
 
     #[test]
     fn given_valid_message_when_stepped_then_writes_payload_to_file() {
@@ -67,11 +83,27 @@ mod tests {
         let file_path = temp_dir.path().join("data_log.bin");
         let mut mapping = HashMap::new();
         let task_id = 42;
+
+        let expected_payload = MockTaskProto {
+            larger_than_zero: 1,
+        };
+
+        let writer =
+            mcap::Writer::new(BufWriter::new(File::create_new(&file_path).unwrap())).unwrap();
+
+        let channel = Arc::new(mcap::Channel {
+            id: 0,
+            topic: "topic".to_string(),
+            schema: Some(Arc::new(MockTaskProto::translate_schema())),
+            message_encoding: "protobuf".to_string(),
+            metadata: BTreeMap::new(),
+        });
         mapping.insert(
             task_id,
             WriteTarget {
                 path: file_path.clone(),
-                writer: BufWriter::new(File::create_new(&file_path).unwrap()),
+                writer,
+                channel,
             },
         );
 
@@ -81,12 +113,11 @@ mod tests {
             receiver,
         };
 
-        let expected_payload = b"test payload bytes".to_vec();
         sender
             .send(DiskLoggerMessage {
                 logger_id: task_id,
                 publish_timestamp: Utc::now(),
-                payload: expected_payload.clone(),
+                payload: expected_payload.encode_length_delimited_to_vec(),
             })
             .unwrap();
 
@@ -94,12 +125,26 @@ mod tests {
 
         assert!(matches!(state, TaskState::Running),);
 
-        // We must drop the logger (and its BufWriter) to ensure the internal
+        // We must drop the logger (and its McapWriter) to ensure the internal
         // buffer flushes its contents to the actual disk before we test reading it.
         drop(logger);
 
-        let written_contents = fs::read(&file_path).unwrap();
-        assert_eq!(written_contents, expected_payload,);
+        let contents = std::fs::read(&file_path).unwrap();
+        let mut mcap_stream = mcap::MessageStream::new(&contents).unwrap();
+
+        // Pull the first message from the MCAP file
+        let mcap_message = mcap_stream
+            .next()
+            .expect("Expected at least one MCAP message in the file")
+            .unwrap();
+
+        // Check that the data stripped from the MCAP framing matches our raw protobuf bytes
+        assert_eq!(
+            mcap_message.data,
+            expected_payload.encode_length_delimited_to_vec()
+        );
+
+        assert!(mcap_stream.next().is_none());
     }
 
     #[test]
@@ -107,11 +152,23 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let file_path = temp_dir.path().join("empty_test.bin");
         let mut mapping = HashMap::new();
+
+        let logger_id = 1;
+        let writer =
+            mcap::Writer::new(BufWriter::new(File::create_new(&file_path).unwrap())).unwrap();
+        let channel = Arc::new(mcap::Channel {
+            id: 0,
+            topic: "topic".to_string(),
+            schema: Some(Arc::new(MockTaskProto::translate_schema())),
+            message_encoding: "protobuf".to_string(),
+            metadata: BTreeMap::new(),
+        });
         mapping.insert(
-            1,
+            logger_id,
             WriteTarget {
                 path: file_path.clone(),
-                writer: BufWriter::new(File::create_new(&file_path).unwrap()),
+                writer,
+                channel,
             },
         );
 
@@ -131,11 +188,23 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let file_path = temp_dir.path().join("disconnect_test.bin");
         let mut mapping = HashMap::new();
+
+        let logger_id = 1;
+        let writer =
+            mcap::Writer::new(BufWriter::new(File::create_new(&file_path).unwrap())).unwrap();
+        let channel = Arc::new(mcap::Channel {
+            id: 0,
+            topic: "topic".to_string(),
+            schema: Some(Arc::new(MockTaskProto::translate_schema())),
+            message_encoding: "protobuf".to_string(),
+            metadata: BTreeMap::new(),
+        });
         mapping.insert(
-            1,
+            logger_id,
             WriteTarget {
                 path: file_path.clone(),
-                writer: BufWriter::new(File::create_new(&file_path).unwrap()),
+                writer,
+                channel,
             },
         );
 
@@ -158,11 +227,23 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let file_path = temp_dir.path().join("unregistered_test.bin");
         let mut mapping = HashMap::new();
+
+        let logger_id = 1;
+        let writer =
+            mcap::Writer::new(BufWriter::new(File::create_new(&file_path).unwrap())).unwrap();
+        let channel = Arc::new(mcap::Channel {
+            id: 0,
+            topic: "topic".to_string(),
+            schema: Some(Arc::new(MockTaskProto::translate_schema())),
+            message_encoding: "protobuf".to_string(),
+            metadata: BTreeMap::new(),
+        });
         mapping.insert(
-            1,
+            logger_id,
             WriteTarget {
                 path: file_path.clone(),
-                writer: BufWriter::new(File::create_new(&file_path).unwrap()),
+                writer,
+                channel,
             },
         );
 

--- a/src/core/central_disk_logger/task.rs
+++ b/src/core/central_disk_logger/task.rs
@@ -4,18 +4,18 @@ use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 
 use crate::core::central_disk_logger::errors;
-use crate::core::central_disk_logger::interface::{ChannelID, DiskLoggerMessage};
+use crate::core::central_disk_logger::interface::{DiskLoggerMessage, LoggerID};
 use crate::core::thread_manager::{SteppableTask, TaskState};
 
 #[derive(Debug)]
 pub struct CentralDiskLogger {
     receiver: crossbeam_channel::Receiver<DiskLoggerMessage>,
-    id_to_path_writer_pair_mapping: HashMap<ChannelID, (PathBuf, BufWriter<File>)>,
+    id_to_path_writer_pair_mapping: HashMap<LoggerID, (PathBuf, BufWriter<File>)>,
 }
 impl CentralDiskLogger {
     pub fn new(
         receiver: crossbeam_channel::Receiver<DiskLoggerMessage>,
-        id_to_path_writer_pair_mapping: HashMap<ChannelID, (PathBuf, BufWriter<File>)>,
+        id_to_path_writer_pair_mapping: HashMap<LoggerID, (PathBuf, BufWriter<File>)>,
     ) -> Self {
         Self {
             receiver,
@@ -30,9 +30,9 @@ impl SteppableTask for CentralDiskLogger {
             Ok(message) => {
                 match self
                     .id_to_path_writer_pair_mapping
-                    .get_mut(&message.channel_id)
+                    .get_mut(&message.logger_id)
                     .ok_or(errors::CentralDiskLoggerError::TaskNotRegistered(
-                        message.channel_id,
+                        message.logger_id,
                     )) {
                     Ok((path, writer)) => {
                         let _ = writer.write_all(&message.payload).map_err(|err| {
@@ -83,7 +83,7 @@ mod tests {
         let expected_payload = b"test payload bytes".to_vec();
         sender
             .send(DiskLoggerMessage {
-                channel_id: task_id,
+                logger_id: task_id,
                 publish_timestamp: Utc::now(),
                 payload: expected_payload.clone(),
             })
@@ -173,7 +173,7 @@ mod tests {
 
         sender
             .send(DiskLoggerMessage {
-                channel_id: 99,
+                logger_id: 99,
                 publish_timestamp: Utc::now(),
                 payload: b"ghost payload".to_vec(),
             })

--- a/src/core/central_disk_logger/task.rs
+++ b/src/core/central_disk_logger/task.rs
@@ -7,7 +7,6 @@ use crate::core::central_disk_logger::errors;
 use crate::core::central_disk_logger::interface::{DiskLoggerMessage, LoggerID};
 use crate::core::thread_manager::{SteppableTask, TaskState};
 
-#[derive(Debug)]
 pub struct CentralDiskLogger {
     receiver: crossbeam_channel::Receiver<DiskLoggerMessage>,
     id_to_path_writer_pair_mapping: HashMap<LoggerID, (PathBuf, BufWriter<File>)>,

--- a/src/core/central_disk_logger/task.rs
+++ b/src/core/central_disk_logger/task.rs
@@ -7,18 +7,23 @@ use crate::core::central_disk_logger::errors;
 use crate::core::central_disk_logger::interface::{DiskLoggerMessage, LoggerID};
 use crate::core::thread_manager::{SteppableTask, TaskState};
 
+#[derive(Debug)]
+pub struct WriteTarget {
+    pub path: PathBuf,
+    pub writer: BufWriter<File>,
+}
 pub struct CentralDiskLogger {
     receiver: crossbeam_channel::Receiver<DiskLoggerMessage>,
-    id_to_path_writer_pair_mapping: HashMap<LoggerID, (PathBuf, BufWriter<File>)>,
+    id_to_target_mapping: HashMap<LoggerID, WriteTarget>,
 }
 impl CentralDiskLogger {
     pub fn new(
         receiver: crossbeam_channel::Receiver<DiskLoggerMessage>,
-        id_to_path_writer_pair_mapping: HashMap<LoggerID, (PathBuf, BufWriter<File>)>,
+        id_to_target_mapping: HashMap<LoggerID, WriteTarget>,
     ) -> Self {
         Self {
             receiver,
-            id_to_path_writer_pair_mapping,
+            id_to_target_mapping,
         }
     }
 }
@@ -27,16 +32,13 @@ impl SteppableTask for CentralDiskLogger {
     fn step(&mut self) -> TaskState {
         match self.receiver.try_recv() {
             Ok(message) => {
-                match self
-                    .id_to_path_writer_pair_mapping
-                    .get_mut(&message.logger_id)
-                    .ok_or(errors::CentralDiskLoggerError::TaskNotRegistered(
-                        message.logger_id,
-                    )) {
-                    Ok((path, writer)) => {
-                        let _ = writer.write_all(&message.payload).map_err(|err| {
+                match self.id_to_target_mapping.get_mut(&message.logger_id).ok_or(
+                    errors::CentralDiskLoggerError::TaskNotRegistered(message.logger_id),
+                ) {
+                    Ok(target) => {
+                        let _ = target.writer.write_all(&message.payload).map_err(|err| {
                             let write_error = errors::CentralDiskLoggerError::WriteError {
-                                path: path.clone(),
+                                path: target.path.clone(),
                                 payload: message.payload,
                                 source: err,
                             };
@@ -67,15 +69,15 @@ mod tests {
         let task_id = 42;
         mapping.insert(
             task_id,
-            (
-                file_path.clone(),
-                BufWriter::new(File::create_new(&file_path).unwrap()),
-            ),
+            WriteTarget {
+                path: file_path.clone(),
+                writer: BufWriter::new(File::create_new(&file_path).unwrap()),
+            },
         );
 
         let (sender, receiver) = crossbeam_channel::unbounded();
         let mut logger = CentralDiskLogger {
-            id_to_path_writer_pair_mapping: mapping,
+            id_to_target_mapping: mapping,
             receiver,
         };
 
@@ -107,15 +109,15 @@ mod tests {
         let mut mapping = HashMap::new();
         mapping.insert(
             1,
-            (
-                file_path.clone(),
-                BufWriter::new(File::create_new(&file_path).unwrap()),
-            ),
+            WriteTarget {
+                path: file_path.clone(),
+                writer: BufWriter::new(File::create_new(&file_path).unwrap()),
+            },
         );
 
         let (_sender, receiver) = crossbeam_channel::unbounded();
         let mut logger = CentralDiskLogger {
-            id_to_path_writer_pair_mapping: mapping,
+            id_to_target_mapping: mapping,
             receiver,
         };
 
@@ -131,15 +133,15 @@ mod tests {
         let mut mapping = HashMap::new();
         mapping.insert(
             1,
-            (
-                file_path.clone(),
-                BufWriter::new(File::create_new(&file_path).unwrap()),
-            ),
+            WriteTarget {
+                path: file_path.clone(),
+                writer: BufWriter::new(File::create_new(&file_path).unwrap()),
+            },
         );
 
         let (sender, receiver) = crossbeam_channel::unbounded();
         let mut logger = CentralDiskLogger {
-            id_to_path_writer_pair_mapping: mapping,
+            id_to_target_mapping: mapping,
             receiver,
         };
 
@@ -158,15 +160,15 @@ mod tests {
         let mut mapping = HashMap::new();
         mapping.insert(
             1,
-            (
-                file_path.clone(),
-                BufWriter::new(File::create_new(&file_path).unwrap()),
-            ),
+            WriteTarget {
+                path: file_path.clone(),
+                writer: BufWriter::new(File::create_new(&file_path).unwrap()),
+            },
         );
 
         let (sender, receiver) = crossbeam_channel::unbounded();
         let mut logger = CentralDiskLogger {
-            id_to_path_writer_pair_mapping: mapping,
+            id_to_target_mapping: mapping,
             receiver,
         };
 

--- a/src/core/central_disk_logger/task.rs
+++ b/src/core/central_disk_logger/task.rs
@@ -4,18 +4,18 @@ use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 
 use crate::core::central_disk_logger::errors;
-use crate::core::central_disk_logger::interface::{DiskLoggerMessage, LoggerTaskID};
+use crate::core::central_disk_logger::interface::{ChannelID, DiskLoggerMessage};
 use crate::core::thread_manager::{SteppableTask, TaskState};
 
 #[derive(Debug)]
 pub struct CentralDiskLogger {
     receiver: crossbeam_channel::Receiver<DiskLoggerMessage>,
-    id_to_path_writer_pair_mapping: HashMap<LoggerTaskID, (PathBuf, BufWriter<File>)>,
+    id_to_path_writer_pair_mapping: HashMap<ChannelID, (PathBuf, BufWriter<File>)>,
 }
 impl CentralDiskLogger {
     pub fn new(
         receiver: crossbeam_channel::Receiver<DiskLoggerMessage>,
-        id_to_path_writer_pair_mapping: HashMap<LoggerTaskID, (PathBuf, BufWriter<File>)>,
+        id_to_path_writer_pair_mapping: HashMap<ChannelID, (PathBuf, BufWriter<File>)>,
     ) -> Self {
         Self {
             receiver,
@@ -30,9 +30,9 @@ impl SteppableTask for CentralDiskLogger {
             Ok(message) => {
                 match self
                     .id_to_path_writer_pair_mapping
-                    .get_mut(&message.logger_id)
+                    .get_mut(&message.channel_id)
                     .ok_or(errors::CentralDiskLoggerError::TaskNotRegistered(
-                        message.logger_id,
+                        message.channel_id,
                     )) {
                     Ok((path, writer)) => {
                         let _ = writer.write_all(&message.payload).map_err(|err| {
@@ -55,6 +55,8 @@ impl SteppableTask for CentralDiskLogger {
 }
 #[cfg(test)]
 mod tests {
+    use chrono::Utc;
+
     use super::*;
     use std::fs;
 
@@ -81,7 +83,8 @@ mod tests {
         let expected_payload = b"test payload bytes".to_vec();
         sender
             .send(DiskLoggerMessage {
-                logger_id: task_id,
+                channel_id: task_id,
+                publish_timestamp: Utc::now(),
                 payload: expected_payload.clone(),
             })
             .unwrap();
@@ -170,7 +173,8 @@ mod tests {
 
         sender
             .send(DiskLoggerMessage {
-                logger_id: 99,
+                channel_id: 99,
+                publish_timestamp: Utc::now(),
                 payload: b"ghost payload".to_vec(),
             })
             .unwrap();

--- a/src/core/central_disk_logger/testing/integration_tests.rs
+++ b/src/core/central_disk_logger/testing/integration_tests.rs
@@ -5,8 +5,6 @@ use chrono::Utc;
 use prost::Message;
 
 use super::test_helpers::*;
-use crate::core::central_disk_logger::interface::IntoLogMessage;
-use crate::core::central_disk_logger::interface::LogSender;
 use crate::core::central_disk_logger::*;
 use crate::core::thread_manager::*;
 

--- a/src/core/central_disk_logger/testing/integration_tests.rs
+++ b/src/core/central_disk_logger/testing/integration_tests.rs
@@ -1,8 +1,11 @@
+use std::convert::Infallible;
 use std::fs;
 
+use chrono::Utc;
 use prost::Message;
 
 use super::test_helpers::*;
+use crate::core::central_disk_logger::interface::IntoLogMessage;
 use crate::core::central_disk_logger::interface::LogSender;
 use crate::core::central_disk_logger::*;
 use crate::core::thread_manager::*;
@@ -92,6 +95,20 @@ fn given_multiple_handles_when_messages_sent_concurrently_then_system_routes_cor
     assert_eq!(fs::read(&file_path_2).unwrap(), expected_2);
 }
 
+#[derive(Debug)]
+struct JsonMessage {
+    pub contents: Vec<String>,
+}
+impl IntoLogMessage<Vec<String>> for JsonMessage {
+    type Error = Infallible;
+    fn into_message(self) -> Result<Vec<String>, Self::Error> {
+        Ok(self.contents)
+    }
+    fn message_timestamp(&self) -> chrono::prelude::DateTime<chrono::prelude::Utc> {
+        Utc::now()
+    }
+}
+
 #[test]
 fn given_jsonl_logger_when_message_sent_and_stepped_then_correct_json_lines_on_disk() {
     let temp_dir = tempfile::tempdir().unwrap();
@@ -103,7 +120,9 @@ fn given_jsonl_logger_when_message_sent_and_stepped_then_correct_json_lines_on_d
         .expect("Failed to register jsonl logger");
     let mut central_logger = registry.build();
 
-    let domain_message = vec!["app_started".to_string(), "disk_ok".to_string()];
+    let domain_message = JsonMessage {
+        contents: vec!["app_started".to_string(), "disk_ok".to_string()],
+    };
 
     handle
         .send(domain_message)
@@ -144,7 +163,10 @@ fn given_mixed_loggers_when_messages_sent_then_system_routes_both_formats_correc
         })
         .unwrap();
 
-    let json_msg = vec!["concurrent_test".to_string()];
+    let json_msg = JsonMessage {
+        contents: vec!["concurrent_test".to_string()],
+    };
+
     jsonl_handle.send(json_msg).unwrap();
 
     central_logger.step();

--- a/src/core/central_disk_logger/testing/integration_tests.rs
+++ b/src/core/central_disk_logger/testing/integration_tests.rs
@@ -106,6 +106,20 @@ impl IntoLogMessage<Vec<String>> for JsonMessage {
         Utc::now()
     }
 }
+impl McapSchemaDescriptor for Vec<String> {
+    fn encoding() -> &'static str {
+        "json"
+    }
+    fn schema_bytes() -> Vec<u8> {
+        b"mock_bytes".to_vec()
+    }
+    fn schema_name() -> String {
+        "tests.json_message".to_string()
+    }
+    fn topic() -> String {
+        "some".to_string()
+    }
+}
 
 #[test]
 fn given_jsonl_logger_when_message_sent_and_stepped_then_correct_json_lines_on_disk() {

--- a/src/core/central_disk_logger/testing/integration_tests.rs
+++ b/src/core/central_disk_logger/testing/integration_tests.rs
@@ -3,6 +3,8 @@ use std::fs;
 
 use chrono::Utc;
 use prost::Message;
+use schemars::JsonSchema;
+use serde::Serialize;
 
 use super::test_helpers::*;
 use crate::core::central_disk_logger::*;
@@ -93,7 +95,7 @@ fn given_multiple_handles_when_messages_sent_concurrently_then_system_routes_cor
     assert_eq!(fs::read(&file_path_2).unwrap(), expected_2);
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, JsonSchema)]
 struct JsonMessage {
     pub contents: Vec<String>,
 }
@@ -104,20 +106,6 @@ impl IntoLogMessage<Vec<String>> for JsonMessage {
     }
     fn message_timestamp(&self) -> chrono::prelude::DateTime<chrono::prelude::Utc> {
         Utc::now()
-    }
-}
-impl McapSchemaDescriptor for Vec<String> {
-    fn encoding() -> &'static str {
-        "json"
-    }
-    fn schema_bytes() -> Vec<u8> {
-        b"mock_bytes".to_vec()
-    }
-    fn schema_name() -> String {
-        "tests.json_message".to_string()
-    }
-    fn topic() -> String {
-        "some".to_string()
     }
 }
 

--- a/src/core/central_disk_logger/testing/integration_tests.rs
+++ b/src/core/central_disk_logger/testing/integration_tests.rs
@@ -1,5 +1,4 @@
 use std::convert::Infallible;
-use std::fs;
 
 use chrono::Utc;
 use prost::Message;
@@ -13,11 +12,11 @@ use crate::core::thread_manager::*;
 #[test]
 fn given_complete_system_when_message_sent_and_stepped_then_correct_bytes_on_disk() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let file_path = temp_dir.path().join("system_log.pb");
+    let file_path = temp_dir.path().join("system_log.mcap");
 
     let mut registry = DiskLoggerRegistry::new();
     let handle = registry
-        .register_proto::<MockTaskProto>(file_path.clone())
+        .register_proto::<MockTaskProto>(file_path.clone(), "test".to_string())
         .expect("Failed to register logger");
     let mut central_logger = registry.build();
 
@@ -38,23 +37,29 @@ fn given_complete_system_when_message_sent_and_stepped_then_correct_bytes_on_dis
     };
     let expected_bytes = expected_proto.encode_length_delimited_to_vec();
 
-    let disk_contents = fs::read(&file_path).unwrap();
-    assert_eq!(disk_contents, expected_bytes);
+    let contents = std::fs::read(&file_path).unwrap();
+    let mcap_message = mcap::MessageStream::new(&contents)
+        .unwrap()
+        .next()
+        .expect("Expected at least one MCAP message in the file")
+        .unwrap();
+
+    assert_eq!(mcap_message.data, expected_bytes);
 }
 
 #[test]
 fn given_multiple_handles_when_messages_sent_concurrently_then_system_routes_correctly() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let file_path_1 = temp_dir.path().join("flight_data.pb");
-    let file_path_2 = temp_dir.path().join("engine_data.pb");
+    let file_path_1 = temp_dir.path().join("flight_data.mcap");
+    let file_path_2 = temp_dir.path().join("engine_data.mcap");
 
     let mut registry = DiskLoggerRegistry::new();
 
     let log_handle_1 = registry
-        .register_proto::<MockTaskProto>(file_path_1.clone())
+        .register_proto::<MockTaskProto>(file_path_1.clone(), "test".to_string())
         .unwrap();
     let log_handle_2 = registry
-        .register_proto::<MockTaskProto>(file_path_2.clone())
+        .register_proto::<MockTaskProto>(file_path_2.clone(), "test".to_string())
         .unwrap();
 
     let mut central_logger = registry.build();
@@ -86,23 +91,38 @@ fn given_multiple_handles_when_messages_sent_concurrently_then_system_routes_cor
         larger_than_zero: 111,
     }
     .encode_length_delimited_to_vec();
+
+    let contents_1 = std::fs::read(&file_path_1).unwrap();
+    let mcap_message_1 = mcap::MessageStream::new(&contents_1)
+        .unwrap()
+        .next()
+        .expect("Expected at least one MCAP message in the file")
+        .unwrap();
+
+    assert_eq!(mcap_message_1.data, expected_1);
+
+    let contents_2 = std::fs::read(&file_path_2).unwrap();
+    let mcap_message_2 = mcap::MessageStream::new(&contents_2)
+        .unwrap()
+        .next()
+        .expect("Expected at least one MCAP message in the file")
+        .unwrap();
+
     let expected_2 = MockTaskProto {
         larger_than_zero: 222,
     }
     .encode_length_delimited_to_vec();
-
-    assert_eq!(fs::read(&file_path_1).unwrap(), expected_1);
-    assert_eq!(fs::read(&file_path_2).unwrap(), expected_2);
+    assert_eq!(mcap_message_2.data, expected_2);
 }
 
-#[derive(Debug, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema, Clone)]
 struct JsonMessage {
     pub contents: Vec<String>,
 }
-impl IntoLogMessage<Vec<String>> for JsonMessage {
+impl IntoLogMessage<JsonMessage> for JsonMessage {
     type Error = Infallible;
-    fn into_message(self) -> Result<Vec<String>, Self::Error> {
-        Ok(self.contents)
+    fn into_message(self) -> Result<JsonMessage, Self::Error> {
+        Ok(self)
     }
     fn message_timestamp(&self) -> chrono::prelude::DateTime<chrono::prelude::Utc> {
         Utc::now()
@@ -112,17 +132,18 @@ impl IntoLogMessage<Vec<String>> for JsonMessage {
 #[test]
 fn given_jsonl_logger_when_message_sent_and_stepped_then_correct_json_lines_on_disk() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let file_path = temp_dir.path().join("events_log.jsonl");
+    let file_path = temp_dir.path().join("events_log.mcap");
 
     let mut registry = DiskLoggerRegistry::new();
     let handle = registry
-        .register_jsonl::<Vec<String>>(file_path.clone())
+        .register_jsonl::<JsonMessage>(file_path.clone(), "test".to_string())
         .expect("Failed to register jsonl logger");
     let mut central_logger = registry.build();
 
     let domain_message = JsonMessage {
         contents: vec!["app_started".to_string(), "disk_ok".to_string()],
     };
+    let expected_bytes = serde_json::to_vec(&domain_message).unwrap();
 
     handle
         .send(domain_message)
@@ -133,26 +154,30 @@ fn given_jsonl_logger_when_message_sent_and_stepped_then_correct_json_lines_on_d
 
     drop(central_logger);
 
-    let expected_jsonl = "[\"app_started\",\"disk_ok\"]\n";
+    let contents = std::fs::read(&file_path).unwrap();
+    let mcap_message = mcap::MessageStream::new(&contents)
+        .unwrap()
+        .next()
+        .expect("Expected at least one MCAP message in the file")
+        .unwrap();
 
-    let disk_contents = fs::read_to_string(&file_path).unwrap();
-    assert_eq!(disk_contents, expected_jsonl);
+    assert_eq!(mcap_message.data, expected_bytes);
 }
 
 #[test]
 fn given_mixed_loggers_when_messages_sent_then_system_routes_both_formats_correctly() {
     let temp_dir = tempfile::tempdir().unwrap();
 
-    let proto_path = temp_dir.path().join("flight_data.pb");
-    let jsonl_path = temp_dir.path().join("system_events.jsonl");
+    let proto_path = temp_dir.path().join("flight_data.mcap");
+    let jsonl_path = temp_dir.path().join("system_events.mcap");
 
     let mut registry = DiskLoggerRegistry::new();
 
     let proto_handle = registry
-        .register_proto::<MockTaskProto>(proto_path.clone())
+        .register_proto::<MockTaskProto>(proto_path.clone(), "test".to_string())
         .unwrap();
     let jsonl_handle = registry
-        .register_jsonl::<Vec<String>>(jsonl_path.clone())
+        .register_jsonl::<JsonMessage>(jsonl_path.clone(), "test".to_string())
         .unwrap();
 
     let mut central_logger = registry.build();
@@ -167,7 +192,7 @@ fn given_mixed_loggers_when_messages_sent_then_system_routes_both_formats_correc
         contents: vec!["concurrent_test".to_string()],
     };
 
-    jsonl_handle.send(json_msg).unwrap();
+    jsonl_handle.send(json_msg.clone()).unwrap();
 
     central_logger.step();
     central_logger.step();
@@ -178,8 +203,23 @@ fn given_mixed_loggers_when_messages_sent_then_system_routes_both_formats_correc
         larger_than_zero: 333,
     }
     .encode_length_delimited_to_vec();
-    assert_eq!(fs::read(&proto_path).unwrap(), expected_proto);
 
-    let expected_jsonl = "[\"concurrent_test\"]\n";
-    assert_eq!(fs::read_to_string(&jsonl_path).unwrap(), expected_jsonl);
+    let proto_contents = std::fs::read(&proto_path).unwrap();
+    let proto_mcap_message = mcap::MessageStream::new(&proto_contents)
+        .unwrap()
+        .next()
+        .expect("Expected at least one MCAP message in the file")
+        .unwrap();
+
+    assert_eq!(proto_mcap_message.data, expected_proto);
+
+    let expected_jsonl = serde_json::to_vec(&json_msg).unwrap();
+    let jsonl_contents = std::fs::read(&jsonl_path).unwrap();
+    let jsonl_mcap_message = mcap::MessageStream::new(&jsonl_contents)
+        .unwrap()
+        .next()
+        .expect("Expected at least one MCAP message in the file")
+        .unwrap();
+
+    assert_eq!(jsonl_mcap_message.data, expected_jsonl);
 }

--- a/src/core/central_disk_logger/testing/test_helpers.rs
+++ b/src/core/central_disk_logger/testing/test_helpers.rs
@@ -1,7 +1,28 @@
+use chrono::Utc;
+
+use crate::core::central_disk_logger::{errors::ProtoLoggingError, interface::IntoLogMessage};
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct MockTaskStruct {
     pub larger_than_zero: i32,
 }
+impl IntoLogMessage<MockTaskProto> for MockTaskStruct {
+    type Error = ProtoLoggingError<MockTaskStruct>;
+
+    fn message_timestamp(&self) -> chrono::prelude::DateTime<chrono::prelude::Utc> {
+        Utc::now()
+    }
+    fn into_message(self) -> Result<MockTaskProto, Self::Error> {
+        if self.larger_than_zero <= 0 {
+            Err(ProtoLoggingError::Conversion(self))
+        } else {
+            Ok(MockTaskProto {
+                larger_than_zero: self.larger_than_zero,
+            })
+        }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub struct MockConversionError;
 
@@ -9,18 +30,4 @@ pub struct MockConversionError;
 pub struct MockTaskProto {
     #[prost(int32, tag = "1")]
     pub larger_than_zero: i32,
-}
-
-impl TryFrom<MockTaskStruct> for MockTaskProto {
-    type Error = MockConversionError;
-
-    fn try_from(task_struct: MockTaskStruct) -> Result<Self, Self::Error> {
-        if task_struct.larger_than_zero <= 0 {
-            Err(MockConversionError)
-        } else {
-            Ok(MockTaskProto {
-                larger_than_zero: task_struct.larger_than_zero,
-            })
-        }
-    }
 }

--- a/src/core/central_disk_logger/testing/test_helpers.rs
+++ b/src/core/central_disk_logger/testing/test_helpers.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 
-use crate::core::central_disk_logger::{errors::ProtoLoggingError, interface::IntoLogMessage};
+use crate::core::central_disk_logger::{IntoLogMessage, ProtoLoggingError};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct MockTaskStruct {

--- a/src/core/central_disk_logger/testing/test_helpers.rs
+++ b/src/core/central_disk_logger/testing/test_helpers.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 
-use crate::core::central_disk_logger::{IntoLogMessage, ProtoLoggingError, ProtoToMcapSchema};
+use crate::core::central_disk_logger::errors::ProtoLoggingError;
+use crate::core::central_disk_logger::{IntoLogMessage, ProtoToMcapSchema};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct MockTaskStruct {

--- a/src/core/central_disk_logger/testing/test_helpers.rs
+++ b/src/core/central_disk_logger/testing/test_helpers.rs
@@ -24,9 +24,6 @@ impl IntoLogMessage<MockTaskProto> for MockTaskStruct {
     }
 }
 
-#[derive(Debug, PartialEq)]
-pub struct MockConversionError;
-
 #[derive(Clone, PartialEq, prost::Message)]
 pub struct MockTaskProto {
     #[prost(int32, tag = "1")]

--- a/src/core/central_disk_logger/testing/test_helpers.rs
+++ b/src/core/central_disk_logger/testing/test_helpers.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 
-use crate::core::central_disk_logger::{IntoLogMessage, ProtoLoggingError};
+use crate::core::central_disk_logger::{IntoLogMessage, McapSchemaDescriptor, ProtoLoggingError};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct MockTaskStruct {
@@ -30,4 +30,18 @@ pub struct MockConversionError;
 pub struct MockTaskProto {
     #[prost(int32, tag = "1")]
     pub larger_than_zero: i32,
+}
+impl McapSchemaDescriptor for MockTaskProto {
+    fn encoding() -> &'static str {
+        "protobuf"
+    }
+    fn schema_bytes() -> Vec<u8> {
+        b"mock_protobuf_descriptor_set_bytes".to_vec()
+    }
+    fn schema_name() -> String {
+        "tests.MockTaskProto".to_string()
+    }
+    fn topic() -> String {
+        "/test/mock_task".to_string()
+    }
 }

--- a/src/core/central_disk_logger/testing/test_helpers.rs
+++ b/src/core/central_disk_logger/testing/test_helpers.rs
@@ -32,7 +32,7 @@ pub struct MockTaskProto {
 impl ProtoToMcapSchema for MockTaskProto {
     fn translate_schema() -> mcap::Schema<'static> {
         mcap::Schema {
-            id: 0,
+            id: 1,
             name: "test".to_string(),
             encoding: "protobuf".to_string(),
             data: (&[1, 2]).into(),

--- a/src/core/central_disk_logger/testing/test_helpers.rs
+++ b/src/core/central_disk_logger/testing/test_helpers.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 
-use crate::core::central_disk_logger::{IntoLogMessage, McapSchemaDescriptor, ProtoLoggingError};
+use crate::core::central_disk_logger::{IntoLogMessage, ProtoLoggingError, ProtoToMcapSchema};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct MockTaskStruct {
@@ -31,17 +31,13 @@ pub struct MockTaskProto {
     #[prost(int32, tag = "1")]
     pub larger_than_zero: i32,
 }
-impl McapSchemaDescriptor for MockTaskProto {
-    fn encoding() -> &'static str {
-        "protobuf"
-    }
-    fn schema_bytes() -> Vec<u8> {
-        b"mock_protobuf_descriptor_set_bytes".to_vec()
-    }
-    fn schema_name() -> String {
-        "tests.MockTaskProto".to_string()
-    }
-    fn topic() -> String {
-        "/test/mock_task".to_string()
+impl ProtoToMcapSchema for MockTaskProto {
+    fn translate_schema() -> mcap::Schema<'static> {
+        mcap::Schema {
+            id: 0,
+            name: "test".to_string(),
+            encoding: "protobuf".to_string(),
+            data: (&[1, 2]).into(),
+        }
     }
 }

--- a/src/core/central_disk_logger/traits.rs
+++ b/src/core/central_disk_logger/traits.rs
@@ -24,7 +24,7 @@ use crate::pb::ALL_PROTOS_DESCRIPTOR;
 impl<T: prost::Name> ProtoToMcapSchema for T {
     fn translate_schema() -> mcap::Schema<'static> {
         mcap::Schema {
-            id: 0,
+            id: 1,
             name: format!("{}.{}", T::PACKAGE, T::NAME),
             encoding: "protobuf".to_string(),
             data: ALL_PROTOS_DESCRIPTOR.to_vec().into(),
@@ -39,7 +39,7 @@ impl<T: schemars::JsonSchema> JsonToMcapSchema for T {
 
         let schema_name = std::any::type_name::<T>().replace("::", ".");
         mcap::Schema {
-            id: 0,
+            id: 1,
             name: schema_name,
             encoding: "json".to_string(),
             data: Cow::Owned(schema_bytes),

--- a/src/core/central_disk_logger/traits.rs
+++ b/src/core/central_disk_logger/traits.rs
@@ -10,3 +10,10 @@ pub trait IntoLogMessage<M> {
     fn into_message(self) -> Result<M, Self::Error>;
     fn message_timestamp(&self) -> DateTime<Utc>;
 }
+
+pub trait McapSchemaDescriptor {
+    fn schema_name() -> String;
+    fn encoding() -> &'static str;
+    fn schema_bytes() -> Vec<u8>;
+    fn topic() -> String;
+}

--- a/src/core/central_disk_logger/traits.rs
+++ b/src/core/central_disk_logger/traits.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chrono::{DateTime, Utc};
 
 pub trait LogSender<M> {
@@ -11,9 +13,36 @@ pub trait IntoLogMessage<M> {
     fn message_timestamp(&self) -> DateTime<Utc>;
 }
 
-pub trait McapSchemaDescriptor {
-    fn schema_name() -> String;
-    fn encoding() -> &'static str;
-    fn schema_bytes() -> Vec<u8>;
-    fn topic() -> String;
+pub trait ProtoToMcapSchema {
+    fn translate_schema() -> mcap::Schema<'static>;
+}
+pub trait JsonToMcapSchema {
+    fn translate_schema() -> mcap::Schema<'static>;
+}
+
+use crate::pb::ALL_PROTOS_DESCRIPTOR;
+impl<T: prost::Name> ProtoToMcapSchema for T {
+    fn translate_schema() -> mcap::Schema<'static> {
+        mcap::Schema {
+            id: 0,
+            name: format!("{}.{}", T::PACKAGE, T::NAME),
+            encoding: "protobuf".to_string(),
+            data: ALL_PROTOS_DESCRIPTOR.to_vec().into(),
+        }
+    }
+}
+impl<T: schemars::JsonSchema> JsonToMcapSchema for T {
+    fn translate_schema() -> mcap::Schema<'static> {
+        let schema = schemars::schema_for!(T);
+        let schema_bytes =
+            serde_json::to_vec(&schema).expect("Failed to serialize JsonSchema to bytes");
+
+        let schema_name = std::any::type_name::<T>().replace("::", ".");
+        mcap::Schema {
+            id: 0,
+            name: schema_name,
+            encoding: "json".to_string(),
+            data: Cow::Owned(schema_bytes),
+        }
+    }
 }

--- a/src/core/central_disk_logger/traits.rs
+++ b/src/core/central_disk_logger/traits.rs
@@ -1,0 +1,12 @@
+use chrono::{DateTime, Utc};
+
+pub trait LogSender<M> {
+    type Error;
+    fn send(&self, message: M) -> Result<(), Self::Error>;
+}
+
+pub trait IntoLogMessage<M> {
+    type Error;
+    fn into_message(self) -> Result<M, Self::Error>;
+    fn message_timestamp(&self) -> DateTime<Utc>;
+}

--- a/src/ingestor/conversion.rs
+++ b/src/ingestor/conversion.rs
@@ -1,8 +1,24 @@
 use std::time::SystemTime;
 
+use crate::core::central_disk_logger::interface::IntoLogMessage;
 use crate::ingestor::errors::APRSPacketConversionError;
 use crate::ingestor::task::AprsPacket;
 use crate::pb::ingestor::PbAprsPacket;
+
+impl IntoLogMessage<PbAprsPacket> for AprsPacket {
+    type Error = std::convert::Infallible;
+    fn message_timestamp(&self) -> chrono::prelude::DateTime<chrono::prelude::Utc> {
+        self.timestamp
+    }
+    fn into_message(self) -> Result<PbAprsPacket, Self::Error> {
+        let sys_time: SystemTime = self.timestamp.into();
+
+        Ok(PbAprsPacket {
+            timestamp: Some(sys_time.into()),
+            message: self.message,
+        })
+    }
+}
 
 impl TryFrom<PbAprsPacket> for AprsPacket {
     type Error = APRSPacketConversionError;
@@ -18,16 +34,5 @@ impl TryFrom<PbAprsPacket> for AprsPacket {
             timestamp,
             message: pb_packet.message,
         })
-    }
-}
-
-impl From<AprsPacket> for PbAprsPacket {
-    fn from(packet: AprsPacket) -> Self {
-        let sys_time: SystemTime = packet.timestamp.into();
-
-        Self {
-            timestamp: Some(sys_time.into()),
-            message: packet.message,
-        }
     }
 }

--- a/src/ingestor/conversion.rs
+++ b/src/ingestor/conversion.rs
@@ -1,6 +1,6 @@
 use std::time::SystemTime;
 
-use crate::core::central_disk_logger::interface::IntoLogMessage;
+use crate::core::central_disk_logger::IntoLogMessage;
 use crate::ingestor::errors::APRSPacketConversionError;
 use crate::ingestor::task::AprsPacket;
 use crate::pb::ingestor::PbAprsPacket;

--- a/src/ingestor/task.rs
+++ b/src/ingestor/task.rs
@@ -356,7 +356,7 @@ mod test {
     fn when_ingestor_reads_from_log_file_then_sender_receives_expected_aprs_packet(
         test_path: TestPath,
     ) {
-        let log_path = &test_path.path.join("test_ingestor_log.pb");
+        let log_path = &test_path.path.join("test_ingestor_log.mcap");
 
         let now = std::time::SystemTime::now();
         let timestamp = prost_types::Timestamp::from(now);
@@ -394,7 +394,7 @@ mod test {
 
     #[rstest::rstest]
     fn when_reading_from_replay_source_then_delays_are_applied_correctly(test_path: TestPath) {
-        let log_path = test_path.path.join("test_replay_delay.pb");
+        let log_path = test_path.path.join("test_replay_delay.mcap");
 
         let base_time = std::time::SystemTime::now();
         let time_p1 = base_time;

--- a/src/parser/conversion.rs
+++ b/src/parser/conversion.rs
@@ -6,7 +6,7 @@ use ogn_aprs_parser::{AircraftBeacon, ICAOAddress};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::core::central_disk_logger::{IntoLogMessage, McapSchemaDescriptor};
+use crate::core::central_disk_logger::IntoLogMessage;
 use crate::parser::errors::AircraftConversionError;
 use crate::pb::parser::PbAircraft;
 
@@ -52,26 +52,6 @@ pub struct AircraftJson {
     pub ground_track: f64,
     pub ground_speed: f64,
     pub gps_altitude: f64,
-}
-impl McapSchemaDescriptor for AircraftJson {
-    fn schema_name() -> String {
-        "AircraftJson".to_string()
-    }
-    fn encoding() -> &'static str {
-        "jsonschema"
-    }
-
-    fn schema_bytes() -> Vec<u8> {
-        let schema = schemars::schema_for!(AircraftJson);
-
-        let schema_json_string =
-            serde_json::to_string(&schema).expect("Failed to serialize JSON schema");
-
-        schema_json_string.into_bytes()
-    }
-    fn topic() -> String {
-        "aircraft_json".to_string()
-    }
 }
 
 pub fn convert_ogn_aprs_beacon_to_aircraft(

--- a/src/parser/conversion.rs
+++ b/src/parser/conversion.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use ogn_aprs_parser::{AircraftBeacon, ICAOAddress};
 use serde::{Deserialize, Serialize};
 
-use crate::core::central_disk_logger::interface::IntoLogMessage;
+use crate::core::central_disk_logger::IntoLogMessage;
 use crate::parser::errors::AircraftConversionError;
 use crate::pb::parser::PbAircraft;
 

--- a/src/parser/conversion.rs
+++ b/src/parser/conversion.rs
@@ -1,9 +1,11 @@
+use std::convert::Infallible;
 use std::time::SystemTime;
 
 use chrono::{DateTime, Utc};
 use ogn_aprs_parser::{AircraftBeacon, ICAOAddress};
 use serde::{Deserialize, Serialize};
 
+use crate::core::central_disk_logger::interface::IntoLogMessage;
 use crate::parser::errors::AircraftConversionError;
 use crate::pb::parser::PbAircraft;
 
@@ -87,6 +89,16 @@ impl TryFrom<PbAircraft> for Aircraft {
             ground_speed: pb_aircraft.ground_speed,
             gps_altitude: pb_aircraft.gps_altitude,
         })
+    }
+}
+
+impl IntoLogMessage<Aircraft> for Aircraft {
+    type Error = Infallible;
+    fn message_timestamp(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+    fn into_message(self) -> Result<Aircraft, Self::Error> {
+        Ok(self)
     }
 }
 

--- a/src/parser/conversion.rs
+++ b/src/parser/conversion.rs
@@ -3,16 +3,16 @@ use std::time::SystemTime;
 
 use chrono::{DateTime, Utc};
 use ogn_aprs_parser::{AircraftBeacon, ICAOAddress};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::core::central_disk_logger::IntoLogMessage;
+use crate::core::central_disk_logger::{IntoLogMessage, McapSchemaDescriptor};
 use crate::parser::errors::AircraftConversionError;
 use crate::pb::parser::PbAircraft;
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Aircraft {
     pub callsign: String,
-    #[serde(with = "icao_serde")]
     pub icao_address: ICAOAddress,
     pub broadcasted_timestamp: chrono::DateTime<chrono::Utc>,
     pub latitude: f64,
@@ -20,6 +20,58 @@ pub struct Aircraft {
     pub ground_track: f64,
     pub ground_speed: f64,
     pub gps_altitude: f64,
+}
+impl IntoLogMessage<AircraftJson> for Aircraft {
+    type Error = Infallible;
+    fn into_message(self) -> Result<AircraftJson, Self::Error> {
+        Ok(AircraftJson {
+            callsign: self.callsign,
+            icao_address: self.icao_address,
+            broadcasted_timestamp: self.broadcasted_timestamp,
+            latitude: self.latitude,
+            longitude: self.longitude,
+            gps_altitude: self.gps_altitude,
+            ground_speed: self.ground_speed,
+            ground_track: self.ground_track,
+        })
+    }
+    fn message_timestamp(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone, JsonSchema)]
+pub struct AircraftJson {
+    pub callsign: String,
+    #[serde(with = "icao_serde")]
+    #[schemars(with = "u32")]
+    pub icao_address: ICAOAddress,
+    pub broadcasted_timestamp: DateTime<Utc>,
+    pub latitude: f64,
+    pub longitude: f64,
+    pub ground_track: f64,
+    pub ground_speed: f64,
+    pub gps_altitude: f64,
+}
+impl McapSchemaDescriptor for AircraftJson {
+    fn schema_name() -> String {
+        "AircraftJson".to_string()
+    }
+    fn encoding() -> &'static str {
+        "jsonschema"
+    }
+
+    fn schema_bytes() -> Vec<u8> {
+        let schema = schemars::schema_for!(AircraftJson);
+
+        let schema_json_string =
+            serde_json::to_string(&schema).expect("Failed to serialize JSON schema");
+
+        schema_json_string.into_bytes()
+    }
+    fn topic() -> String {
+        "aircraft_json".to_string()
+    }
 }
 
 pub fn convert_ogn_aprs_beacon_to_aircraft(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,5 +2,5 @@ mod conversion;
 pub mod errors;
 mod task;
 
-pub use conversion::Aircraft;
+pub use conversion::{Aircraft, AircraftJson};
 pub use task::AircraftParser;

--- a/src/parser/task.rs
+++ b/src/parser/task.rs
@@ -4,19 +4,19 @@ use crate::core::central_disk_logger::{JsonlLoggerHandle, LogSender};
 use crate::core::thread_manager::{SteppableTask, TaskState};
 use crate::ingestor::AprsPacket;
 use crate::parser::Aircraft;
-use crate::parser::conversion::convert_ogn_aprs_beacon_to_aircraft;
+use crate::parser::conversion::{AircraftJson, convert_ogn_aprs_beacon_to_aircraft};
 
 pub struct AircraftParser {
     receiver: crossbeam_channel::Receiver<AprsPacket>,
     sender: crossbeam_channel::Sender<Aircraft>,
-    logger: Option<JsonlLoggerHandle<Aircraft>>,
+    logger: Option<JsonlLoggerHandle<AircraftJson>>,
 }
 impl AircraftParser {
     #[must_use]
     pub fn new(
         messages_receiver: crossbeam_channel::Receiver<AprsPacket>,
         aircraft_sender: crossbeam_channel::Sender<Aircraft>,
-        logger: Option<JsonlLoggerHandle<Aircraft>>,
+        logger: Option<JsonlLoggerHandle<AircraftJson>>,
     ) -> Self {
         AircraftParser {
             receiver: messages_receiver,

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -1,9 +1,66 @@
+const ALL_PROTOS_DESCRIPTOR: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/file_descriptor_set.bin"));
+
 pub mod ingestor {
     include!(concat!(env!("OUT_DIR"), "/ingestor.rs"));
+
+    use super::ALL_PROTOS_DESCRIPTOR;
+    use crate::core::central_disk_logger::traits::McapSchemaDescriptor;
+
+    impl McapSchemaDescriptor for PbAprsPacket {
+        fn schema_name() -> String {
+            "ingestor.PbAprsPacket".to_string() // Your proto package + message name
+        }
+        fn encoding() -> &'static str {
+            "protobuf"
+        }
+        fn schema_bytes() -> Vec<u8> {
+            ALL_PROTOS_DESCRIPTOR.to_vec()
+        }
+        fn topic() -> String {
+            "/ingestor/aprs".to_string()
+        }
+    }
 }
 pub mod parser {
     include!(concat!(env!("OUT_DIR"), "/parser.rs"));
+
+    use super::ALL_PROTOS_DESCRIPTOR;
+    use crate::core::central_disk_logger::traits::McapSchemaDescriptor;
+
+    impl McapSchemaDescriptor for PbAircraft {
+        fn schema_name() -> String {
+            "parser.PbAircraft".to_string()
+        }
+        fn encoding() -> &'static str {
+            "protobuf"
+        }
+        fn schema_bytes() -> Vec<u8> {
+            ALL_PROTOS_DESCRIPTOR.to_vec()
+        }
+        fn topic() -> String {
+            "/parser/aircraft".to_string()
+        }
+    }
 }
 pub mod airspace {
     include!(concat!(env!("OUT_DIR"), "/airspace.rs"));
+
+    use super::ALL_PROTOS_DESCRIPTOR;
+    use crate::core::central_disk_logger::traits::McapSchemaDescriptor;
+
+    impl McapSchemaDescriptor for PbAirspaceUpdate {
+        fn schema_name() -> String {
+            "airspace.PbAirspaceUpdate".to_string()
+        }
+        fn encoding() -> &'static str {
+            "protobuf"
+        }
+        fn schema_bytes() -> Vec<u8> {
+            ALL_PROTOS_DESCRIPTOR.to_vec()
+        }
+        fn topic() -> String {
+            "/airspace/airspace_update".to_string()
+        }
+    }
 }

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -1,66 +1,12 @@
-const ALL_PROTOS_DESCRIPTOR: &[u8] =
+pub const ALL_PROTOS_DESCRIPTOR: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/file_descriptor_set.bin"));
 
 pub mod ingestor {
     include!(concat!(env!("OUT_DIR"), "/ingestor.rs"));
-
-    use super::ALL_PROTOS_DESCRIPTOR;
-    use crate::core::central_disk_logger::traits::McapSchemaDescriptor;
-
-    impl McapSchemaDescriptor for PbAprsPacket {
-        fn schema_name() -> String {
-            "ingestor.PbAprsPacket".to_string() // Your proto package + message name
-        }
-        fn encoding() -> &'static str {
-            "protobuf"
-        }
-        fn schema_bytes() -> Vec<u8> {
-            ALL_PROTOS_DESCRIPTOR.to_vec()
-        }
-        fn topic() -> String {
-            "/ingestor/aprs".to_string()
-        }
-    }
 }
 pub mod parser {
     include!(concat!(env!("OUT_DIR"), "/parser.rs"));
-
-    use super::ALL_PROTOS_DESCRIPTOR;
-    use crate::core::central_disk_logger::traits::McapSchemaDescriptor;
-
-    impl McapSchemaDescriptor for PbAircraft {
-        fn schema_name() -> String {
-            "parser.PbAircraft".to_string()
-        }
-        fn encoding() -> &'static str {
-            "protobuf"
-        }
-        fn schema_bytes() -> Vec<u8> {
-            ALL_PROTOS_DESCRIPTOR.to_vec()
-        }
-        fn topic() -> String {
-            "/parser/aircraft".to_string()
-        }
-    }
 }
 pub mod airspace {
     include!(concat!(env!("OUT_DIR"), "/airspace.rs"));
-
-    use super::ALL_PROTOS_DESCRIPTOR;
-    use crate::core::central_disk_logger::traits::McapSchemaDescriptor;
-
-    impl McapSchemaDescriptor for PbAirspaceUpdate {
-        fn schema_name() -> String {
-            "airspace.PbAirspaceUpdate".to_string()
-        }
-        fn encoding() -> &'static str {
-            "protobuf"
-        }
-        fn schema_bytes() -> Vec<u8> {
-            ALL_PROTOS_DESCRIPTOR.to_vec()
-        }
-        fn topic() -> String {
-            "/airspace/airspace_update".to_string()
-        }
-    }
 }

--- a/src/pipeline/setup.rs
+++ b/src/pipeline/setup.rs
@@ -3,7 +3,7 @@ use crate::core::central_disk_logger::DiskLoggerRegistry;
 use crate::core::central_disk_logger::errors::DiskloggerRegistryError;
 use crate::core::thread_manager::{SteppableTask, TaskID, ThreadManager};
 use crate::ingestor::{AprsPacket, Ingestor, PbAprsPacket};
-use crate::parser::{Aircraft, AircraftParser};
+use crate::parser::{Aircraft, AircraftJson, AircraftParser};
 use crate::pb::airspace::PbAirspaceUpdate;
 use crate::pipeline::config::{FilePathConfig, IngestorSource, PipelineConfig};
 
@@ -70,7 +70,7 @@ impl AirspaceDataPipeline {
         let parser_logger_handle = pipeline_config
             .parser
             .write_path
-            .map(|path| disk_logger_registry.register_jsonl::<Aircraft>(path))
+            .map(|path| disk_logger_registry.register_jsonl::<AircraftJson>(path))
             .transpose()?;
 
         let parser = AircraftParser::new(ingestor_receiver, parser_sender, parser_logger_handle);

--- a/src/pipeline/setup.rs
+++ b/src/pipeline/setup.rs
@@ -46,7 +46,9 @@ impl AirspaceDataPipeline {
         let ingestor_logger_handle = pipeline_config
             .ingestor
             .write_path
-            .map(|path| disk_logger_registry.register_proto::<PbAprsPacket>(path))
+            .map(|path| {
+                disk_logger_registry.register_proto::<PbAprsPacket>(path, "ingestor".to_string())
+            })
             .transpose()?;
 
         let ingestor = match pipeline_config.ingestor.source {
@@ -70,7 +72,9 @@ impl AirspaceDataPipeline {
         let parser_logger_handle = pipeline_config
             .parser
             .write_path
-            .map(|path| disk_logger_registry.register_jsonl::<AircraftJson>(path))
+            .map(|path| {
+                disk_logger_registry.register_jsonl::<AircraftJson>(path, "parser".to_string())
+            })
             .transpose()?;
 
         let parser = AircraftParser::new(ingestor_receiver, parser_sender, parser_logger_handle);
@@ -78,7 +82,10 @@ impl AirspaceDataPipeline {
         let airspace_logger_handle = pipeline_config
             .airspace
             .write_path
-            .map(|path| disk_logger_registry.register_proto::<PbAirspaceUpdate>(path))
+            .map(|path| {
+                disk_logger_registry
+                    .register_proto::<PbAirspaceUpdate>(path, "airspace".to_string())
+            })
             .transpose()?;
 
         let airspace_store = AirspaceStore::new(
@@ -144,7 +151,7 @@ mod test {
             timestamp: Some(timestamp),
             message,
         };
-        let read_path = test_path.path.join("test_ingestor_log.pb");
+        let read_path = test_path.path.join("test_ingestor_log.mcap");
         let mut writer = std::io::BufWriter::new(std::fs::File::create(&read_path).unwrap());
         let _ = write_pb_message_to_disk(&mut writer, &packet);
         let ingestor_config = IngestorConfig {


### PR DESCRIPTION
This PR changes the central disk logger to log messages in `mcap` format.